### PR TITLE
[#8]feat: 버튼 공용 컴포넌트 구현

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,17 +22,19 @@
   /* Grayscale */
   --gray-50: #ffffff;
   --gray-100: #f5f5f5;
+  --gray-150: #c4c4c4;
   --gray-200: #e6e6e6;
   --gray-300: #d9d9d9;
   --gray-400: #b3b3b3;
   --gray-500: #7a7a79;
+  --gray-600: #808080;
 
   /* Primary Orange */
   --primary-100: #feeeea;
   --primary-200: #fed8d0;
   --primary-300: #fd947f;
   --primary-400: #f9502e;
-  --primary-500: #f9502e;
+  --primary-500: #e04829;
 
   /* Black Scale */
   --black-100: #61605e;

--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import Image from "next/image";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import iconEdit from "@/assets/icon/icon-edit.png";
+
+/**
+ * props
+ * variant: 버튼 타입 (solid, outlined)
+ * state: 버튼 상태 (default, disabled, active, done)
+ * children: 버튼 내용
+ * onClick: 버튼 클릭 시 실행할 함수
+ * isEditButton: 수정 버튼 여부
+ * className: 버튼 추가 클래스
+ * disabled: 버튼 비활성화 여부
+ */
+type SolidState = "default" | "disabled";
+type OutlinedState = "default" | "active" | "done";
+
+type ButtonProps = {
+  variant: "solid" | "outlined";
+  state: SolidState | OutlinedState;
+  children: React.ReactNode;
+  onClick?: () => void;
+  isEditButton?: boolean;
+  className?: string;
+  disabled?: boolean;
+};
+
+export const Button = ({
+  variant,
+  state,
+  children,
+  onClick,
+  isEditButton = false,
+  className = "",
+  disabled = false,
+}: ButtonProps) => {
+  const isMobile = useMediaQuery("(max-width: 767px)");
+
+  /* Solid */
+  const solidBase =
+    "flex items-center justify-center text-gray-50 font-semibold transition-colors duration-200 focus:outline-none ";
+  const solidSize = isMobile
+    ? "h-[54px] w-[327px] text-md rounded-[12px]"
+    : "h-[60px] w-[640px] text-lg rounded-[16px]";
+  let solidState = "bg-primary-400 hover:bg-primary-500";
+  if (state === "disabled" || disabled) solidState = "bg-gray-300 cursor-not-allowed";
+
+  /* Outlined */
+  const outlinedBase =
+    "flex items-center justify-center border-[1px] text-primary-400 font-semibold transition-colors duration-200 focus:outline-none ";
+  const outlinedSize = isMobile
+    ? "h-[54px] w-[327px] text-md rounded-[12px]"
+    : "h-[60px] w-[640px] text-lg rounded-[16px]";
+  let outlinedState = "border-primary-400 text-primary-400 bg-inherit";
+  if (state === "active") outlinedState = "border-primary-400 text-primary-400 bg-primary-100";
+  if (state === "done") outlinedState = "border-gray-150 text-gray-600! bg-inherit";
+
+  /* 버튼 클래스 조합 */
+  const buttonClass =
+    variant === "solid"
+      ? `${solidBase} ${solidSize} ${solidState} ${className}`
+      : `${outlinedBase} ${outlinedSize} ${outlinedState} ${className}`;
+
+  return (
+    <button
+      type="button"
+      className={buttonClass}
+      onClick={onClick}
+      disabled={variant === "solid" ? state === "disabled" || disabled : false}
+    >
+      {children}
+      {/* 수정 아이콘 */}
+      {variant === "solid" && isEditButton && (
+        <Image src={iconEdit} alt="수정" width={24} height={24} className="ml-2" />
+      )}
+    </button>
+  );
+};


### PR DESCRIPTION
## ✨ 작업 개요
- 공용 컴포넌트 button 구현

## ✅ 주요 작업 내용
- Outlined button 디자인
- Outlined button의 interaction(default, hover, disabled) 적용
- 수정 버튼도 props로 추가
- Solid button 디자인
- Solid button의 interaction(default, active, done) 적용
- 반응형 적용

## 🔄 관련 이슈
Closes #8

## 📸 스크린샷 (선택)
| 구현 내용 |           Mobile           |            Tablet & Desktop            |  
| :-------: | :-------------------------: | :-------------------------: | 
|    PNG    | <img width="286" alt="image" src="https://github.com/user-attachments/assets/c736f523-f45b-45c4-b840-fc7bd405b6f6" /> | <img width="281" alt="image" src="https://github.com/user-attachments/assets/3b55a001-e9e9-416b-8b37-6905d5d1b5b3" /> | 

## 🧪 테스트 방법 (선택)
- 공통 컴포넌트 Docs https://admitted-turkey-c17.notion.site/Docs-2245da6dc98c80358a4cddc4b1c962e8
## 📝 비고
- 관련 비고 사항 없음