### PR TITLE
[#14] feat: 공용 컴포넌트 찜 버튼 구현

### DIFF
--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -1,41 +1,36 @@
 import React from "react";
 import Image from "next/image";
-import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { useWindowWidth } from "@/hooks/useWindowWidth";
+import { IButtonProps } from "@/types/button";
 import iconEdit from "@/assets/icon/icon-edit.png";
+import iconLikeBlack from "@/assets/icon/icon-like-black.png";
+import iconUnLike from "@/assets/icon/icon-like-white-lg.png";
 
 /**
- * props
- * variant: 버튼 타입 (solid, outlined)
- * state: 버튼 상태 (default, disabled, active, done)
- * children: 버튼 내용
- * onClick: 버튼 클릭 시 실행할 함수
- * isEditButton: 수정 버튼 여부
- * className: 버튼 추가 클래스
- * disabled: 버튼 비활성화 여부
+ * Button 컴포넌트
+ *
+ * @param variant - 버튼 타입 (solid, outlined, like)
+ * @param state - 버튼 상태 (default, disabled, active, done)
+ * @param children - 버튼 내용
+ * @param onClick - 버튼 클릭 시 실행할 함수
+ * @param isEditButton - 수정 버튼 여부 (solid 버튼에서만 사용)
+ * @param className - 버튼 추가 클래스
+ * @param disabled - 버튼 비활성화 여부 (solid, outlined 버튼에서만 사용)
+ * @param isLiked - 찜(좋아요) 상태 (like 버튼에서만 사용)
  */
-type SolidState = "default" | "disabled";
-type OutlinedState = "default" | "active" | "done";
-
-type ButtonProps = {
-  variant: "solid" | "outlined";
-  state: SolidState | OutlinedState;
-  children: React.ReactNode;
-  onClick?: () => void;
-  isEditButton?: boolean;
-  className?: string;
-  disabled?: boolean;
-};
-
 export const Button = ({
   variant,
-  state,
+  state = "default",
   children,
   onClick,
   isEditButton = false,
   className = "",
   disabled = false,
-}: ButtonProps) => {
-  const isMobile = useMediaQuery("(max-width: 767px)");
+  isLiked = false,
+}: IButtonProps) => {
+  const deviceType = useWindowWidth();
+  const isMobile = deviceType === "mobile";
+  const isTablet = deviceType === "tablet";
 
   /* Solid */
   const solidBase =
@@ -52,9 +47,28 @@ export const Button = ({
   const outlinedSize = isMobile
     ? "h-[54px] w-[327px] text-md rounded-[12px]"
     : "h-[60px] w-[640px] text-lg rounded-[16px]";
-  let outlinedState = "border-primary-400 text-primary-400 bg-inherit";
+  let outlinedState = "border-primary-400 text-primary-400 bg-inherit hover:bg-primary-50";
   if (state === "active") outlinedState = "border-primary-400 text-primary-400 bg-primary-100";
   if (state === "done") outlinedState = "border-gray-150 text-gray-600! bg-inherit";
+
+  /* Like(찜) 버튼 */
+  if (variant === "like") {
+    const likeSize = isMobile || isTablet ? "h-[54px] w-[54px]" : "h-[54px] w-[320px] text-md flex-row";
+    const likeIcon = isLiked ? iconLikeBlack : iconUnLike;
+    const likeIconSize = 24;
+    const likeText =
+      isMobile || isTablet ? null : <span className="ml-[10px] font-semibold text-black">기사님 찜하기</span>;
+    return (
+      <button
+        type="button"
+        className={`flex items-center justify-center rounded-[16px] border-[1px] border-gray-200 transition-all duration-200 focus:outline-none ${likeSize} ${className}`}
+        onClick={onClick}
+      >
+        <Image src={likeIcon} alt="찜" width={likeIconSize} height={likeIconSize} />
+        {likeText}
+      </button>
+    );
+  }
 
   /* 버튼 클래스 조합 */
   const buttonClass =

--- a/src/hooks/useLikeToggle.ts
+++ b/src/hooks/useLikeToggle.ts
@@ -1,0 +1,16 @@
+import { useState } from "react";
+import { IUseLikeToggleProps } from "@/types/button";
+
+export const useLikeToggle = ({ moverId, initialIsLiked = false }: IUseLikeToggleProps) => {
+  const [isLiked, setIsLiked] = useState(initialIsLiked);
+
+  const toggleLike = () => {
+    setIsLiked(!isLiked);
+    console.log(`${moverId} 찜 ${isLiked ? "해제" : "등록"}`);
+  };
+
+  return {
+    isLiked,
+    toggleLike,
+  };
+};

--- a/src/types/button.ts
+++ b/src/types/button.ts
@@ -1,0 +1,26 @@
+import { ReactNode } from "react";
+
+// 버튼 상태 타입
+export type TSolidState = "default" | "disabled";
+export type TOutlinedState = "default" | "active" | "done";
+
+// 버튼 variant 타입
+export type TButtonVariant = "solid" | "outlined" | "like";
+
+// 버튼 Props 인터페이스
+export interface IButtonProps {
+  variant: TButtonVariant;
+  state?: TSolidState | TOutlinedState;
+  children?: ReactNode;
+  onClick?: () => void;
+  isEditButton?: boolean;
+  className?: string;
+  disabled?: boolean;
+  isLiked?: boolean;
+}
+
+// 찜 토글 훅 Props 인터페이스
+export interface IUseLikeToggleProps {
+  moverId: string;
+  initialIsLiked?: boolean;
+}


### PR DESCRIPTION
## ✨ 작업 개요
- Like(찜) 기능을 추가해 3가지 variant를 지원하는 공용 버튼 컴포넌트 구현
- 찜 토글 훅 & 타입 정의

## ✅ 주요 작업 내용
- Like(찜) 반응형 디자인 구현(모바일/태블릿 + 데스크탑)
- 찜 토글 훅 구현(향후 백엔드 연동을 위한 구조 설계)
- 타입 정의 정리(button.ts에 모든 버튼 관련 타입 정의)

## 🔄 관련 이슈
Closes #14

## 📸 스크린샷 (선택)
| 구현 내용 |           Mobile & Tablet           |            Desktop            |  
| :-------: | :-------------------------: | :-------------------------: | 
|    PNG    | <img width="50" alt="image" src="https://github.com/user-attachments/assets/1dd8554c-e0a6-4e7c-8cd1-8986a8cfbbf5" /> <img width="50" alt="image" src="https://github.com/user-attachments/assets/482bee92-c83c-4286-988b-087ff733dc37" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/41580010-33dd-4b3d-a287-a17c9a4b1751" /> <img width="300" alt="image" src="https://github.com/user-attachments/assets/cfee925e-b3a2-41fe-a2df-d46f889a2591" /> | 

## 🧪 테스트 방법 (선택)
- 공통 컴포넌트 Docs https://admitted-turkey-c17.notion.site/Docs-2245da6dc98c80358a4cddc4b1c962e8

## 📝 비고
- 관련 비고 사항 없음