### PR TITLE
[#6]refactor :타입 위치 통일 및 4중삼항 제거 피드백반영

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { LadingPage } from "@/pages/landing/LadingPage";
+
 const HomePage = () => {
-  return <LadingPage />;
+  return <div className="flex text-red-500">랜딩 페이지 입니다</div>;
 };
 
 export default HomePage;

--- a/src/components/common/Chips/CircleTextLabel.tsx
+++ b/src/components/common/Chips/CircleTextLabel.tsx
@@ -1,15 +1,14 @@
 "use client";
 import React, { useState } from "react";
 
-type TProps = {
+interface TProps {
   text: string;
   clickAble?: boolean;
   onClick?: () => void;
-};
+}
 
 export const CircleTextLabel = ({ text, clickAble = false, onClick }: TProps) => {
   const [isClicked, setIsClicked] = useState(false);
-
   const handleClick = () => {
     setIsClicked(!isClicked);
   };

--- a/src/components/common/Chips/CircleTextLabel.tsx
+++ b/src/components/common/Chips/CircleTextLabel.tsx
@@ -1,13 +1,13 @@
 "use client";
 import React, { useState } from "react";
 
-interface TProps {
+interface IProps {
   text: string;
   clickAble?: boolean;
   onClick?: () => void;
 }
 
-export const CircleTextLabel = ({ text, clickAble = false, onClick }: TProps) => {
+export const CircleTextLabel = ({ text, clickAble = false, onClick }: IProps) => {
   const [isClicked, setIsClicked] = useState(false);
   const handleClick = () => {
     setIsClicked(!isClicked);

--- a/src/components/common/Chips/MoveTypeLabel.tsx
+++ b/src/components/common/Chips/MoveTypeLabel.tsx
@@ -4,25 +4,25 @@ import home from "../../../assets/icon/icon-home.png";
 import office from "../../../assets/icon/icon-office.png";
 import document from "../../../assets/icon/icon-document.png";
 
-type TProps = {
+interface TProps {
   type: "small" | "home" | "office" | "document";
-};
+}
+
+const MOVE_TYPE_LABELS = {
+  small: "소형이사",
+  home: "가정이사",
+  office: "사무실이사",
+  document: "지정 견적 요청",
+} as const;
+
+const MOVE_TYPE_ICONS = {
+  small: small,
+  home: home,
+  office: office,
+  document: document,
+} as const;
 
 export const MoveTypeLabel = ({ type }: TProps) => {
-  const MOVE_TYPE_LABELS = {
-    small: "소형이사",
-    home: "가정이사",
-    office: "사무실이사",
-    document: "지정 견적 요청",
-  } as const;
-
-  const MOVE_TYPE_ICONS = {
-    small: small,
-    home: home,
-    office: office,
-    document: document,
-  } as const;
-
   const label = MOVE_TYPE_LABELS[type];
   const iconSrc = MOVE_TYPE_ICONS[type];
 

--- a/src/components/common/Chips/MoveTypeLabel.tsx
+++ b/src/components/common/Chips/MoveTypeLabel.tsx
@@ -4,7 +4,7 @@ import home from "../../../assets/icon/icon-home.png";
 import office from "../../../assets/icon/icon-office.png";
 import document from "../../../assets/icon/icon-document.png";
 
-interface TProps {
+interface IProps {
   type: "small" | "home" | "office" | "document";
 }
 
@@ -22,7 +22,7 @@ const MOVE_TYPE_ICONS = {
   document: document,
 } as const;
 
-export const MoveTypeLabel = ({ type }: TProps) => {
+export const MoveTypeLabel = ({ type }: IProps) => {
   const label = MOVE_TYPE_LABELS[type];
   const iconSrc = MOVE_TYPE_ICONS[type];
 

--- a/src/components/common/Chips/MoveTypeLabel.tsx
+++ b/src/components/common/Chips/MoveTypeLabel.tsx
@@ -1,28 +1,39 @@
 import Image from "next/image";
-import box from "../../../assets/icon/icon-box.png";
+import small from "../../../assets/icon/icon-box.png";
 import home from "../../../assets/icon/icon-home.png";
 import office from "../../../assets/icon/icon-office.png";
 import document from "../../../assets/icon/icon-document.png";
 
-export const MoveTypeLabel = ({ type }: { type: "small" | "home" | "office" | "document" }) => {
+type TProps = {
+  type: "small" | "home" | "office" | "document";
+};
+
+export const MoveTypeLabel = ({ type }: TProps) => {
+  const MOVE_TYPE_LABELS = {
+    small: "소형이사",
+    home: "가정이사",
+    office: "사무실이사",
+    document: "지정 견적 요청",
+  } as const;
+
+  const MOVE_TYPE_ICONS = {
+    small: small,
+    home: home,
+    office: office,
+    document: document,
+  } as const;
+
+  const label = MOVE_TYPE_LABELS[type];
+  const iconSrc = MOVE_TYPE_ICONS[type];
+
   return (
     <div>
       <div className="bg-primary-100 inline-flex h-[26px] items-center justify-start gap-[2px] rounded-sm py-[2px] pr-[7px] pl-[4px] md:h-[32px] md:py-[4px]">
         <div className="relative h-[20px] w-[20px]">
-          <Image
-            src={type === "small" ? box : type === "home" ? home : type === "office" ? office : document}
-            alt="movetype"
-            fill
-          />
+          <Image src={iconSrc} alt="movetype" fill />
         </div>
-        <p className="text-primary-400 inline-block text-center text-sm text-[13px] leading-[22px] font-semibold md:text-[14px] md:leading-[24px]">
-          {type === "small"
-            ? "소형이사"
-            : type === "home"
-              ? "가정이사"
-              : type === "office"
-                ? "사무실이사"
-                : "지정 견적 요청"}
+        <p className="text-primary-400 text-center text-[13px] leading-[22px] font-semibold md:text-[14px] md:leading-[24px]">
+          {label}
         </p>
       </div>
     </div>


### PR DESCRIPTION
## ✨ 작업 개요
- chips 컴포넌트 타입 선언 위치 통일 
- 다중 삼항연산자 제거

## ✅ 주요 작업 내용
-  chip 컴포넌트 코드 리펙토링 

## 🔄 관련 이슈
Closes #6 

## 📸 스크린샷 (선택)


## 🧪 테스트 방법 (선택)
- 공통 컴포넌트 Docs https://admitted-turkey-c17.notion.site/Docs-2245da6dc98c80358a4cddc4b1c962e8

## 📝 비고
- (버그, 추후 개선사항 등)