### PR TITLE
[#38]feat:공용 컴포넌트 모달 제작

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,8 +1,13 @@
+import { ModalProvider } from "@/components/common/modal/ModalContext";
 import QueryProvider from "@/providers/QueryProvider";
 import React from "react";
 
 const Providers = ({ children }: { children: React.ReactNode }) => {
-  return <QueryProvider>{children}</QueryProvider>;
+  return (
+    <QueryProvider>
+      <ModalProvider>{children}</ModalProvider>
+    </QueryProvider>
+  );
 };
 
 export default Providers;

--- a/src/components/common/modal/ModalContext.tsx
+++ b/src/components/common/modal/ModalContext.tsx
@@ -2,26 +2,9 @@
 
 import React, { createContext, useContext, useState, ReactNode, useEffect, useCallback } from "react";
 import { Button } from "@/components/common/button/Button";
+import type { IModalButton, IModalOptions, IModalContextType } from "@/types/modal";
 
-interface ModalButton {
-  text: string;
-  onClick: () => void;
-  disabled?: boolean;
-}
-
-export interface ModalOptions {
-  title: string;
-  children: ReactNode;
-  buttons?: ModalButton[];
-  type?: "center" | "bottomSheet"; // 추가
-}
-
-interface ModalContextType {
-  open: (options: ModalOptions) => void;
-  close: () => void;
-}
-
-const ModalContext = createContext<ModalContextType | undefined>(undefined);
+const ModalContext = createContext<IModalContextType | undefined>(undefined);
 
 export function useModal() {
   const ctx = useContext(ModalContext);
@@ -30,9 +13,9 @@ export function useModal() {
 }
 
 export function ModalProvider({ children }: { children: ReactNode }) {
-  const [modal, setModal] = useState<ModalOptions | null>(null);
+  const [modal, setModal] = useState<IModalOptions | null>(null);
 
-  const open = (options: ModalOptions) => setModal(options);
+  const open = (options: IModalOptions) => setModal(options);
   const close = () => setModal(null);
 
   return (
@@ -43,7 +26,7 @@ export function ModalProvider({ children }: { children: ReactNode }) {
   );
 }
 
-function ModalLayout({ title, children, buttons, onClose, type = "center" }: ModalOptions & { onClose: () => void }) {
+function ModalLayout({ title, children, buttons, onClose, type = "center" }: IModalOptions & { onClose: () => void }) {
   // ESC 키로 닫기
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/src/components/common/modal/ModalContext.tsx
+++ b/src/components/common/modal/ModalContext.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import React, { createContext, useContext, useState, ReactNode, useEffect, useCallback } from "react";
+import { Button } from "@/components/common/button/Button";
+
+interface ModalButton {
+  text: string;
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+export interface ModalOptions {
+  title: string;
+  children: ReactNode;
+  buttons?: ModalButton[];
+  type?: "center" | "bottomSheet"; // 추가
+}
+
+interface ModalContextType {
+  open: (options: ModalOptions) => void;
+  close: () => void;
+}
+
+const ModalContext = createContext<ModalContextType | undefined>(undefined);
+
+export function useModal() {
+  const ctx = useContext(ModalContext);
+  if (!ctx) throw new Error("모달 컨텍스트를 찾을 수 없습니다.");
+  return ctx;
+}
+
+export function ModalProvider({ children }: { children: ReactNode }) {
+  const [modal, setModal] = useState<ModalOptions | null>(null);
+
+  const open = (options: ModalOptions) => setModal(options);
+  const close = () => setModal(null);
+
+  return (
+    <ModalContext.Provider value={{ open, close }}>
+      {children}
+      {modal && <ModalLayout {...modal} onClose={close} />}
+    </ModalContext.Provider>
+  );
+}
+
+function ModalLayout({ title, children, buttons, onClose, type = "center" }: ModalOptions & { onClose: () => void }) {
+  // ESC 키로 닫기
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  // 바깥 영역 클릭 시 닫기
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (e.target === e.currentTarget) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  // type이 bottomSheet일 때 PC/태블릿에서는 center로 강제
+  const [responsiveType, setResponsiveType] = useState(type);
+
+  useEffect(() => {
+    function handleResize() {
+      if (type === "bottomSheet") {
+        setResponsiveType(window.innerWidth < 768 ? "bottomSheet" : "center");
+      } else {
+        setResponsiveType(type);
+      }
+    }
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [type, title, children, buttons]);
+
+  const modalClass =
+    responsiveType === "bottomSheet"
+      ? "fixed bottom-0 left-0 right-0 z-50 rounded-t-3xl bg-gray-50 px-4 py-6 shadow-xl transition-all duration-300 ease-out w-full max-w-md mx-auto"
+      : "relative min-w-[293px] rounded-3xl bg-gray-50 px-4 py-6 shadow-xl transition-all duration-300 ease-out md:min-w-152 md:px-6 md:pt-8 md:pb-10";
+
+  const wrapperClass =
+    responsiveType === "bottomSheet"
+      ? "fixed inset-0 z-50 flex items-end justify-center bg-black/50"
+      : "fixed inset-0 z-50 flex items-center justify-center bg-black/50";
+
+  return (
+    <div className={wrapperClass} onClick={handleBackdropClick}>
+      <div className={modalClass}>
+        {/* 헤더 */}
+        <div className="mb-[30px] flex items-center justify-between md:mb-[42px]">
+          <h2 className="text-2lg truncate pr-4 leading-[26px] font-bold md:text-2xl md:leading-8 md:font-semibold">
+            {title}
+          </h2>
+          <button
+            onClick={onClose}
+            className="flex-shrink-0 cursor-pointer rounded-full p-1 text-gray-400 transition-colors"
+            aria-label="모달 닫기"
+          >
+            <svg
+              className="h-6 w-6 md:h-9 md:w-9"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+        {/* 내용 */}
+        <div className="text-2lg text-black-300 mb-6 leading-[26px] font-medium md:mb-10">{children}</div>
+        {/* 하단 버튼 */}
+        {buttons && (
+          <div className="flex gap-2">
+            {buttons.map((btn, i) => (
+              <Button
+                key={i}
+                variant="solid"
+                onClick={btn.onClick}
+                disabled={btn.disabled}
+                width="w-full"
+                height="h-[54px] md:h-16 "
+                rounded="rounded-xl md:rounded-2xl "
+                fontSize="text-base md:text-2lg"
+              >
+                {btn.text}
+              </Button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/types/modal.ts
+++ b/src/types/modal.ts
@@ -1,0 +1,17 @@
+export interface IModalButton {
+  text: string;
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+export interface IModalOptions {
+  title: string;
+  children: React.ReactNode;
+  buttons?: IModalButton[];
+  type?: "center" | "bottomSheet";
+}
+
+export interface IModalContextType {
+  open: (options: IModalOptions) => void;
+  close: () => void;
+}


### PR DESCRIPTION
## ✨ 작업 개요
- 프로젝트 전역에서 사용할 수 있는 공통 모달 컴포넌트를 구현했습니다.
- 모바일에서는 바텀시트, PC/태블릿에서는 센터 모달로 자동 전환되는 반응형 모달입니다.

## ✅ 주요 작업 내용
- ModalProvider, useModal 커스텀 훅을 통한 전역 모달 관리 구조 설계
- ModalOptions에 type(center/bottomSheet) 옵션 추가 및 반응형 분기 로직 구현
- 버튼, 제목, 내용 등 다양한 커스텀 옵션 지원
- ESC 키, 바깥 영역 클릭 시 닫기 등 접근성 기능 반영
- 팀원용 사용법 DOCS 별도 작성

## 🔄 관련 이슈
Closes #38

## 📸 스크린샷 (선택)


## 🧪 테스트 방법 (선택)

## 📝 비고
- 추후 디자인/애니메이션 등 추가 커스터마이징 가능
- 팀원들이 쉽게 사용할 수 있도록 사용법 문서화 완료
- 공통적인 스타일만 틀로 잡은 모달입니다