### PR TITLE
[#63]fix:addressCard chips 컴포넌트 사용으로 변경

### DIFF
--- a/src/components/common/card/AddressCard.tsx
+++ b/src/components/common/card/AddressCard.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { CircleTextLabel } from "../chips/CircleTextLabel";
 
 // 공통 스타일 정의
 const styles = {
@@ -20,16 +21,12 @@ const AddressCard = ({ postalCode, roadAddress, jibunAddress }: IAddressCardProp
       <label className={styles.postalCode}>{postalCode || "우편번호"}</label>
 
       <div className="flex w-full items-start gap-2">
-        <div className="flex items-start gap-2">
-          <label className={styles.label}>도로명</label>
-        </div>
+        <CircleTextLabel text="도로명" />
         <span className={styles.addressText}>{roadAddress || "도로명 주소를 입력해주세요"}</span>
       </div>
 
       <div className="flex w-full items-start gap-2">
-        <div className="flex items-start gap-2">
-          <label className={styles.label}>지번</label>
-        </div>
+        <CircleTextLabel text="지번" />
         <span className={styles.addressText}>{jibunAddress || "지번 주소를 입력해주세요"}</span>
       </div>
 


### PR DESCRIPTION
## ✨ 작업 개요
- AddressCard 컴포넌트를 label 태그를 이용해 제작한 사항을 chips 컴포넌트를 사용하도록 변경

## ✅ 주요 작업 내용
 ```
 <CircleTextLabel text="도로명" />
```

## 🔄 관련 이슈
Closes #63

## 📸 스크린샷 (선택)

## 🧪 테스트 방법 (선택)


## 📝 비고
- 