### PR TITLE
[#65]feat:이사 유형 카드 컴포넌트 제작

### DIFF
--- a/src/components/common/card/MovingTypeCard.tsx
+++ b/src/components/common/card/MovingTypeCard.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import CheckIcon from "@/assets/icon/checkbox/icon-checkbox-circle-active.png";
 import Image from "next/image";
 
-interface MovingTypeCardProps {
+interface IMovingTypeCardProps {
   selected: boolean;
   label: string;
   description: string;
@@ -10,7 +10,7 @@ interface MovingTypeCardProps {
   onClick: () => void;
 }
 
-const MovingTypeCard = ({ selected, label, description, image, onClick }: MovingTypeCardProps) => {
+const MovingTypeCard = ({ selected, label, description, image, onClick }: IMovingTypeCardProps) => {
   return (
     <button
       type="button"

--- a/src/components/common/card/MovingTypeCard.tsx
+++ b/src/components/common/card/MovingTypeCard.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import CheckIcon from "@/assets/icon/checkbox/icon-checkbox-circle-active.png";
+import Image from "next/image";
+
+interface MovingTypeCardProps {
+  selected: boolean;
+  label: string;
+  description: string;
+  image: React.ReactNode;
+  onClick: () => void;
+}
+
+const MovingTypeCard = ({ selected, label, description, image, onClick }: MovingTypeCardProps) => {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`w-full rounded-2xl border ${selected ? "border-primary-400 bg-primary-50" : "border-gray-200 bg-white"} flex flex-row items-center gap-4 px-4 py-5 transition-colors duration-200 lg:px-6 lg:py-6`}
+    >
+      {/* 왼쪽 상단 라디오 버튼 */}
+      <div className="flex w-2/3 flex-col items-start">
+        <div className="mb-2">
+          <span
+            className={`inline-block h-6 w-6 items-center justify-center rounded-full border-[1px] ${selected ? "border-primary-400 bg-primary-400" : "border-gray-300 bg-white"} transition-colors`}
+          >
+            {selected && <Image src={CheckIcon} alt="체크" width={24} height={24} />}
+          </span>
+        </div>
+        <div className="text-left">
+          <div className="text-black-500 text-base leading-[26px] font-semibold">{label}</div>
+          <div className="text-[14px] leading-6 font-normal text-gray-500">{description}</div>
+        </div>
+      </div>
+      {/* 이미지 */}
+      <div className="flex w-1/3 items-center justify-end">{image}</div>
+    </button>
+  );
+};
+
+export default MovingTypeCard;


### PR DESCRIPTION
## ✨ 작업 개요
- 견적 요청에 사용되는 이사 유형 카드 컴포넌트 제작

## ✅ 주요 작업 내용
- 이사 유형 카드 컴포넌트 반복적인 디자인 컴포넌트로 제작

## 🔄 관련 이슈
Closes #65

## 📸 스크린샷 (선택)
> ![스크린샷 2025-07-09 181431](https://github.com/user-attachments/assets/0bb6893a-cb19-4d53-9c36-6a01a99ce99e)


## 🧪 테스트 방법 (선택)

## 📝 비고
- 