### PR TITLE
[#69]fix: 주소 카드 seleted 사용으로 선택된 UI 구현

### DIFF
--- a/src/components/common/card/AddressCard.tsx
+++ b/src/components/common/card/AddressCard.tsx
@@ -3,8 +3,6 @@ import { CircleTextLabel } from "../chips/CircleTextLabel";
 
 // 공통 스타일 정의
 const styles = {
-  label:
-    "bg-primary-100 text-primary-400 flex w-11 items-center justify-center rounded-2xl px-[6px] py-[2px] text-[12px] leading-5 font-semibold md:w-[54px] md:text-[14px]",
   addressText: "text-black-250 text-[14px] leading-6 font-normal md:text-base",
   postalCode: "text-black-250 text-[14px] leading-6 font-semibold md:text-base md:leading-[26px]",
 };
@@ -13,11 +11,14 @@ interface IAddressCardProps {
   postalCode?: string;
   roadAddress?: string;
   jibunAddress?: string;
+  selected?: boolean;
 }
 
-const AddressCard = ({ postalCode, roadAddress, jibunAddress }: IAddressCardProps) => {
+const AddressCard = ({ postalCode, roadAddress, jibunAddress, selected = false }: IAddressCardProps) => {
   return (
-    <div className="border-border-light flex min-w-65 flex-col items-start gap-4 rounded-2xl border px-4 pt-5 pb-6 shadow-[2px_2px_10px_0px_rgba(224,224,224,0.20)]">
+    <div
+      className={`flex min-w-65 flex-col items-start gap-4 rounded-2xl border px-4 pt-5 pb-6 shadow-[2px_2px_10px_0px_rgba(224,224,224,0.20)] transition-colors ${selected ? "border-primary-400 bg-primary-100" : "border-border-light bg-white"} `}
+    >
       <label className={styles.postalCode}>{postalCode || "우편번호"}</label>
 
       <div className="flex w-full items-start gap-2">
@@ -29,8 +30,6 @@ const AddressCard = ({ postalCode, roadAddress, jibunAddress }: IAddressCardProp
         <CircleTextLabel text="지번" />
         <span className={styles.addressText}>{jibunAddress || "지번 주소를 입력해주세요"}</span>
       </div>
-
-      <div className="flex w-full items-center gap-2"></div>
     </div>
   );
 };

--- a/src/components/common/card/AddressCard.tsx
+++ b/src/components/common/card/AddressCard.tsx
@@ -19,7 +19,7 @@ const AddressCard = ({ postalCode, roadAddress, jibunAddress, selected = false }
     <div
       className={`flex min-w-65 flex-col items-start gap-4 rounded-2xl border px-4 pt-5 pb-6 shadow-[2px_2px_10px_0px_rgba(224,224,224,0.20)] transition-colors ${selected ? "border-primary-400 bg-primary-100" : "border-border-light bg-white"} `}
     >
-      <label className={styles.postalCode}>{postalCode || "우편번호"}</label>
+      <span className={styles.postalCode}>{postalCode || "우편번호"}</span>
 
       <div className="flex w-full items-start gap-2">
         <CircleTextLabel text="도로명" />


### PR DESCRIPTION
## ✨ 작업 개요
- 주소 카드 컴포넌트 seleted 사용으로 UI 구현

## ✅ 주요 작업 내용
- onClick 과 seleted 선택
- 선택된 seleted로 UI 구현

## 🔄 관련 이슈
Closes #69

## 📸 스크린샷 (선택)
> ![스크린샷 2025-07-09 185554](https://github.com/user-attachments/assets/3d8929d2-666b-43fb-814b-20487f64a8f4)


## 🧪 테스트 방법 (선택)
- 

## 📝 비고
- onClick은 클릭만 구현이 되기 때문에 seleted로 선택함