### PR TITLE
[#86]repactor: 모달 zustand로 변경

### DIFF
--- a/src/components/quote/create/ProgressBar.tsx
+++ b/src/components/quote/create/ProgressBar.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 
-interface ProgressBarProps {
+interface IProgressBarProps {
   value: number; // 0~100 (진행률 %)
 }
 
-const ProgressBar = ({ value }: ProgressBarProps) => {
+const ProgressBar = ({ value }: IProgressBarProps) => {
   // 0~100 사이로 제한
   const safeValue = Math.max(0, Math.min(100, value));
 


### PR DESCRIPTION
## ✨ 작업 개요
- 기존 `contaxt`로 상태관리하는 모달을 `zustand`로 변경

## ✅ 주요 작업 내용
- 기존 `contaxt`로 상태관리하는 모달을 `zustand`로 변경

## 🔄 관련 이슈
Closes #86

## 📸 스크린샷 (선택)


## 🧪 테스트 방법 (선택)


## 📝 비고
- 기존 스타일은 그대로면서 상태관리만 바뀌어 `repactor`로 진행