### PR TITLE
[#27] feat : 회원가입 api 연결 및 테스트

### DIFF
--- a/src/components/common/gnb/Logo.tsx
+++ b/src/components/common/gnb/Logo.tsx
@@ -12,7 +12,6 @@ interface ILogoProps {
 }
 
 export const Logo = ({ size = "mobile", userRole = "guest" }: ILogoProps) => {
-  console.log(size);
   return (
     <Link href="/">
       {userRole !== "guest" && size === "mobile" ? (

--- a/src/lib/api/auth.api.ts
+++ b/src/lib/api/auth.api.ts
@@ -1,0 +1,29 @@
+import { ISignInFormValues, ISignUpFormValues } from "@/types/auth";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+const authApi = {
+  signIn: async (data: ISignInFormValues) => {
+    const response = await fetch(`${API_URL}/auth/sign-in`, {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+      body: JSON.stringify(data),
+    });
+    return response.json();
+  },
+
+  signUp: async (data: ISignUpFormValues) => {
+    const response = await fetch(`${API_URL}/auth/sign-up`, {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+      body: JSON.stringify(data),
+    });
+    return response.json();
+  },
+};
+
+export default authApi;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,8 +7,10 @@ export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   //   // ✅ 쿠키에서 토큰 가져오기
-  //   const accessToken = request.cookies.get("accessToken")?.value;
-  //   const refreshToken = request.cookies.get("refreshToken")?.value;
+  const accessToken = request.cookies.get("accessToken")?.value;
+  const refreshToken = request.cookies.get("refreshToken")?.value;
+
+  console.log(accessToken, refreshToken);
 
   //   /**
   //    * ✅ 토큰 기반 유저 역할 추출

--- a/src/pages/auth/moverSignup/MoverSignupPage.tsx
+++ b/src/pages/auth/moverSignup/MoverSignupPage.tsx
@@ -13,6 +13,7 @@ import naver from "@/assets/icon/auth/icon-login-naver-lg.png";
 import moverAvatarLg from "@/assets/img/mascot/mover-avatartion-lg.png";
 import { useWindowWidth } from "@/hooks/useWindowWidth";
 import { ISignUpFormValues } from "@/types/auth";
+import authApi from "@/lib/api/auth.api";
 
 const MoverSignupPage = () => {
   const deviceType = useWindowWidth();
@@ -31,16 +32,28 @@ const MoverSignupPage = () => {
   // 입력 값 감시
   const name = watch("name");
   const email = watch("email");
-  const phone = watch("phone");
+  const phoneNumber = watch("phoneNumber");
   const password = watch("password");
   const passwordCheck = watch("passwordCheck");
 
   // 회원 가입 버튼 활성화 조건 (값 존재 + validation 통과)
-  const isFormValid = name && email && phone && password && passwordCheck && isValid;
+  const isFormValid = name && email && phoneNumber && password && passwordCheck && isValid;
 
-  const onSubmit = (data: ISignUpFormValues) => {
-    console.log(data);
-    // ✅ TODO: 서버 액션 연동 or mutate
+  const onSubmit = async (data: ISignUpFormValues) => {
+    const signUpData = {
+      email: data.email,
+      password: data.password,
+      name: data.name,
+      phoneNumber: data.phoneNumber,
+      currentRole: "MOVER" as const,
+    };
+
+    try {
+      const response = await authApi.signUp(signUpData);
+      console.log(response);
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   return (
@@ -100,14 +113,14 @@ const MoverSignupPage = () => {
             <div className="mb-6 flex flex-col gap-2 font-normal">
               <span className="text-black-400 text-md">전화번호</span>
               <BaseInput
-                {...register("phone", {
+                {...register("phoneNumber", {
                   required: "전화번호는 필수 입력입니다.",
                   pattern: {
                     value: /^01([0|1|6|7|8|9])-?([0-9]{4})-?([0-9]{4})$/,
                     message: "유효한 전화번호 형식이 아닙니다. ex) 01012345678",
                   },
                 })}
-                error={errors.phone?.message}
+                error={errors.phoneNumber?.message}
                 placeholder="전화번호를 입력해주세요."
                 inputClassName="py-3.5 px-3.5"
                 wrapperClassName="w-full sm:w-full"

--- a/src/pages/auth/userSignup/UserSignupPage.tsx
+++ b/src/pages/auth/userSignup/UserSignupPage.tsx
@@ -13,6 +13,7 @@ import naver from "@/assets/icon/auth/icon-login-naver-lg.png";
 import userAvatarLg from "@/assets/img/mascot/user-avatartion-lg.png";
 import { useWindowWidth } from "@/hooks/useWindowWidth";
 import { ISignUpFormValues } from "@/types/auth";
+import authApi from "@/lib/api/auth.api";
 
 const UserSignupPage = () => {
   const deviceType = useWindowWidth();
@@ -31,16 +32,28 @@ const UserSignupPage = () => {
   // 입력 값 감시
   const name = watch("name");
   const email = watch("email");
-  const phone = watch("phone");
+  const phoneNumber = watch("phoneNumber");
   const password = watch("password");
   const passwordCheck = watch("passwordCheck");
 
   // 회원 가입 버튼 활성화 조건 (값 존재 + validation 통과)
-  const isFormValid = name && email && phone && password && passwordCheck && isValid;
+  const isFormValid = name && email && phoneNumber && password && passwordCheck && isValid;
 
-  const onSubmit = (data: ISignUpFormValues) => {
-    console.log(data);
-    // ✅ TODO: 서버 액션 연동 or mutate
+  const onSubmit = async (data: ISignUpFormValues) => {
+    const signUpData = {
+      email: data.email,
+      password: data.password,
+      name: data.name,
+      phoneNumber: data.phoneNumber,
+      currentRole: "CUSTOMER" as const,
+    };
+
+    try {
+      const response = await authApi.signUp(signUpData);
+      console.log(response);
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   return (
@@ -100,14 +113,14 @@ const UserSignupPage = () => {
             <div className="mb-6 flex flex-col gap-2 font-normal">
               <span className="text-black-400 text-md">전화번호</span>
               <BaseInput
-                {...register("phone", {
+                {...register("phoneNumber", {
                   required: "전화번호는 필수 입력입니다.",
                   pattern: {
                     value: /^01([0|1|6|7|8|9])-?([0-9]{4})-?([0-9]{4})$/,
                     message: "유효한 전화번호 형식이 아닙니다. ex) 01012345678",
                   },
                 })}
-                error={errors.phone?.message}
+                error={errors.phoneNumber?.message}
                 placeholder="전화번호를 입력해주세요."
                 inputClassName="py-3.5 px-3.5"
                 wrapperClassName="w-full sm:w-full"

--- a/src/stores/authStore .ts
+++ b/src/stores/authStore .ts
@@ -6,7 +6,7 @@ interface AuthState {
   user: {
     id: string;
     email: string;
-    currentRole: "USER" | "ADMIN" | "MOVER";
+    currentRole: "USER" | "MOVER";
   } | null;
   setLogin: (token: string, user: AuthState["user"]) => void;
   setLogout: () => void;

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -6,7 +6,8 @@ export interface ISignInFormValues {
 export interface ISignUpFormValues {
   name: string;
   email: string;
-  phone: string;
+  phoneNumber: string;
   password: string;
-  passwordCheck: string;
+  passwordCheck?: string;
+  currentRole: "CUSTOMER" | "MOVER";
 }


### PR DESCRIPTION
## ✨ 작업 개요
- 일반 회원가입 api 연결 및 테스트를 진행했습니다

## ✅ 주요 작업 내용
- [ ] signIn api 호출 인터페이스 구현
- [ ] 일반유저/기사님 회원가입 페이지에서 api 호출 적용 및 테스트

## 🔄 관련 이슈
Closes #27 

## 📸 스크린샷 (선택)
### 일반유저 회원가입 성공
![일반유저회갑](https://github.com/user-attachments/assets/e10c853c-a024-41d3-91ac-bfb6522b2316)
### 일반유저 회원가입 body
![일반유저 회갑 성공](https://github.com/user-attachments/assets/f1b0c297-6cff-4f2b-9d61-0edd0d240d3b)
### 기사님 회원가입 성공
![기사님 회원가입](https://github.com/user-attachments/assets/4b7c4be2-9b92-429d-9595-eea921f3fae7)
### 기사님 회원가입 body
![기사님 성공](https://github.com/user-attachments/assets/a765bdfd-c215-4f89-8810-ec68e73b2cca)

## 📝 비고
- 현재 https 설정이 안되어서 쿠키는 안넘어오는 문제가 있습니다 추후 서버쪽 ssl 설정 후 다시 테스트 진행하겠습니다