### PR TITLE
[#26] feat : 일반 로그인 api 연결 및 테스트, 데브네비게이션 간편 로그인 및 로그인 전역 상태관리 적용

### DIFF
--- a/src/components/common/DevNavitgation.tsx
+++ b/src/components/common/DevNavitgation.tsx
@@ -5,23 +5,23 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useAuth } from "@/hooks/useAuth";
 
-interface RouteGroup {
+interface IRouteGroup {
   title: string;
   routes: Array<{
     name: string;
     path: string;
   }>;
-  allowedRoles?: ("guest" | "USER" | "MOVER")[];
+  allowedRoles?: ("guest" | "CUSTOMER" | "MOVER")[];
 }
 
-const routeGroups: RouteGroup[] = [
+const routeGroups: IRouteGroup[] = [
   {
     title: "메인",
     routes: [
       { name: "홈", path: "/" },
       { name: "404", path: "/not-found" },
     ],
-    allowedRoles: ["guest", "USER", "MOVER"],
+    allowedRoles: ["guest", "CUSTOMER", "MOVER"],
   },
   {
     title: "인증",
@@ -39,7 +39,7 @@ const routeGroups: RouteGroup[] = [
       { name: "프로필 등록", path: "/profile/register" },
       { name: "프로필 수정", path: "/profile/edit" },
     ],
-    allowedRoles: ["USER", "MOVER"],
+    allowedRoles: ["CUSTOMER", "MOVER"],
   },
   {
     title: "기사님 견적 받은 요청/ 내 견적 관리",
@@ -63,7 +63,7 @@ const routeGroups: RouteGroup[] = [
       { name: "유저님 받았던 견적 조회", path: "/quote/received" },
       { name: "유저님 받았던 견적 조회 상세", path: "/quote/received/1" },
     ],
-    allowedRoles: ["USER"],
+    allowedRoles: ["CUSTOMER"],
   },
   {
     title: "기사님 찾기",
@@ -71,12 +71,12 @@ const routeGroups: RouteGroup[] = [
       { name: "기사님 찾기", path: "/searchMover" },
       { name: "기사님 상세", path: "/searchMover/1" },
     ],
-    allowedRoles: ["guest", "USER"],
+    allowedRoles: ["guest", "CUSTOMER"],
   },
   {
     title: "찜한 기사님",
     routes: [{ name: "찜한 기사님", path: "/favoriteMover" }],
-    allowedRoles: ["USER"],
+    allowedRoles: ["CUSTOMER"],
   },
   {
     title: "기사 마이페이지",
@@ -92,7 +92,7 @@ const routeGroups: RouteGroup[] = [
       { name: "작성 가능한 리뷰", path: "/review/writable" },
       { name: "작성한 리뷰", path: "/review/written" },
     ],
-    allowedRoles: ["USER"],
+    allowedRoles: ["CUSTOMER"],
   },
 ];
 
@@ -102,11 +102,11 @@ export const DevNavitgation = () => {
   const { isLoggedIn, user, login, logout } = useAuth();
 
   // 현재 유저 역할 결정
-  const currentRole = isLoggedIn ? user?.currentRole : "guest";
+  const currentRole = isLoggedIn ? user?.userRole : "guest";
 
   // 현재 유저가 접근 가능한 라우트 그룹 필터링
   const filteredRouteGroups = routeGroups.filter((group) =>
-    group.allowedRoles?.includes(currentRole as "guest" | "USER" | "MOVER" | "ADMIN"),
+    group.allowedRoles?.includes(currentRole as "guest" | "CUSTOMER" | "MOVER"),
   );
 
   useEffect(() => {
@@ -120,29 +120,30 @@ export const DevNavitgation = () => {
     localStorage.setItem("devNavVisible", newVisibility.toString());
   };
 
+  // TODO : 현재 로그인 정보가 맞지 않음 서버에 해당 데이터 넣고 다시 테스트
   const handleLogin = () => {
-    // 테스트용 로그인 (실제로는 적절한 토큰과 유저 정보를 받아야 함)
-    const mockUser = {
-      id: "test-user",
-      email: "test@example.com",
-      currentRole: "USER" as const,
+    // 테스트용 로그인
+    const mockCustomer = {
+      email: "testCustomer@test.com",
+      password: "1rhdiddl!",
     };
-    login("mock-token", mockUser);
+    login(mockCustomer.email, mockCustomer.password);
   };
 
   const handleMoverLogin = () => {
     // 테스트용 기사 로그인
     const mockMover = {
-      id: "test-mover",
-      email: "mover@example.com",
-      currentRole: "MOVER" as const,
+      email: "testMover@test.com",
+      password: "1rhdiddl!",
     };
-    login("mock-token", mockMover);
+    login(mockMover.email, mockMover.password);
   };
 
   useEffect(() => {
+    // TODO : 추후 삭제 예정
     console.log("현재 로그인 상태", isLoggedIn);
-    console.log("현재 유저 역할", user?.currentRole || "비회원");
+    console.log("현재 유저 역할", user?.userRole || "비회원");
+    console.log("현재 유저 이메일", user?.userName || "비회원");
   }, [isLoggedIn, user]);
 
   // 개발 환경에서만 표시
@@ -166,9 +167,7 @@ export const DevNavitgation = () => {
             <div className="mb-4 flex items-center justify-between">
               <h3 className="text-black-500 text-lg font-semibold">🚧 Dev Navigation</h3>
               <div className="flex items-center gap-2">
-                <span className="text-sm text-gray-600">
-                  {isLoggedIn ? `${user?.currentRole}: ${user?.email}` : "비회원"}
-                </span>
+                <span className="text-sm text-gray-600">{isLoggedIn ? `이름: ${user?.userName}` : "비회원"}</span>
                 {isLoggedIn ? (
                   <button onClick={logout} className="rounded bg-red-500 px-3 py-1 text-xs text-white hover:bg-red-600">
                     로그아웃

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,21 +1,27 @@
+import authApi from "@/lib/api/auth.api";
 import { useAuthStore } from "@/stores/authStore ";
 
-type User = {
-  id: string;
-  email: string;
-  currentRole: "USER" | "ADMIN" | "MOVER";
-};
-
 export const useAuth = () => {
-  const { isLoggedIn, user, accessToken, setLogin, setLogout } = useAuthStore();
+  const { isLoggedIn, user, setLogin, setLogout } = useAuthStore();
 
-  const login = (token: string, user: User) => {
-    setLogin(token, user);
+  const login = async (email: string, password: string) => {
+    try {
+      const response = await authApi.signIn({
+        email,
+        password,
+      });
+
+      setLogin(response.user);
+
+      return response;
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   const logout = () => {
     setLogout();
   };
 
-  return { isLoggedIn, user, accessToken, login, logout };
+  return { isLoggedIn, user, login, logout };
 };

--- a/src/lib/api/auth.api.ts
+++ b/src/lib/api/auth.api.ts
@@ -10,6 +10,7 @@ const authApi = {
       },
       method: "POST",
       body: JSON.stringify(data),
+      credentials: "include",
     });
     return response.json();
   },
@@ -21,6 +22,7 @@ const authApi = {
       },
       method: "POST",
       body: JSON.stringify(data),
+      credentials: "include",
     });
     return response.json();
   },

--- a/src/pages/auth/moverSignin/MoverSigninPage.tsx
+++ b/src/pages/auth/moverSignin/MoverSigninPage.tsx
@@ -13,8 +13,11 @@ import naver from "@/assets/icon/auth/icon-login-naver-lg.png";
 import { useWindowWidth } from "@/hooks/useWindowWidth";
 import moverAvatarLg from "@/assets/img/mascot/mover-avatartion-lg.png";
 import { ISignInFormValues } from "@/types/auth";
+import { useAuth } from "@/hooks/useAuth";
 
 const MoverSigninPage = () => {
+  const { login } = useAuth();
+
   const deviceType = useWindowWidth();
 
   const form = useForm<ISignInFormValues>({
@@ -35,9 +38,12 @@ const MoverSigninPage = () => {
   // 로그인 버튼 활성화 조건 (값 존재 + validation 통과)
   const isFormValid = email && password && email.trim() !== "" && password.trim() !== "" && isValid;
 
-  const onSubmit = (data: ISignInFormValues) => {
-    console.log(data);
-    // ✅ TODO: 서버 액션 연동 or mutate
+  const onSubmit = async () => {
+    try {
+      await login(email, password);
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   return (

--- a/src/pages/auth/userSignin/UserSigninPage.tsx
+++ b/src/pages/auth/userSignin/UserSigninPage.tsx
@@ -14,8 +14,10 @@ import userAvatar from "@/assets/img/mascot/user-avatartion.png";
 import userAvatarLg from "@/assets/img/mascot/user-avatartion-lg.png";
 import { useWindowWidth } from "@/hooks/useWindowWidth";
 import { ISignInFormValues } from "@/types/auth";
+import { useAuth } from "@/hooks/useAuth";
 
 const UserSigninPage = () => {
+  const { login } = useAuth();
   const deviceType = useWindowWidth();
 
   const form = useForm<ISignInFormValues>({
@@ -36,9 +38,12 @@ const UserSigninPage = () => {
   // 로그인 버튼 활성화 조건 (값 존재 + validation 통과)
   const isFormValid = email && password && email.trim() !== "" && password.trim() !== "" && isValid;
 
-  const onSubmit = (data: ISignInFormValues) => {
-    console.log(data);
-    // ✅ TODO: 서버 액션 연동 or mutate
+  const onSubmit = async () => {
+    try {
+      await login(email, password);
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   return (

--- a/src/stores/authStore .ts
+++ b/src/stores/authStore .ts
@@ -2,32 +2,28 @@ import { create } from "zustand";
 
 interface AuthState {
   isLoggedIn: boolean;
-  accessToken: string | null;
   user: {
     id: string;
-    email: string;
-    currentRole: "USER" | "MOVER";
+    userName: string;
+    userRole: "CUSTOMER" | "MOVER";
   } | null;
-  setLogin: (token: string, user: AuthState["user"]) => void;
+  setLogin: (user: AuthState["user"]) => void;
   setLogout: () => void;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
   isLoggedIn: false,
-  accessToken: null,
   user: null,
 
-  setLogin: (token, user) =>
+  setLogin: (user) =>
     set(() => ({
       isLoggedIn: true,
-      accessToken: token,
       user,
     })),
 
   setLogout: () =>
     set(() => ({
       isLoggedIn: false,
-      accessToken: null,
       user: null,
     })),
 }));


### PR DESCRIPTION
## ✨ 작업 개요
- 로그인 페이지의 기능을 구현합니다

## ✅ 주요 작업 내용
- [x] 일반 로그인 유효성 검사 로직 구현
- [x] 일반 로그인 api 연동 및 확인
- [x] 데브네비게이션 간편 로그인 구현

## 🔄 관련 이슈
Closes #26 

## 📸 스크린샷 (선택)
### 일반 로그인 전
<img width="1915" height="930" alt="일반 로그인 전" src="https://github.com/user-attachments/assets/e6841049-ec77-4587-8cb9-00f145030b2a" />

### 일반 로그인 후
<img width="1907" height="911" alt="일반 로그인 후" src="https://github.com/user-attachments/assets/3f4357eb-b655-4dae-bde2-573e61753c50" />

## 🧪 테스트 방법
- [x] 현재 서버에 들어있는 유저 정보로 로그인후 데브네비게이션 정보가 바뀌었는지 확인
- [x] 데브네비게이션에서 간편 로그인후 정보 변경 확인

## 📝 비고
- 현재 쿠키는 넘어오나 https 설정이 안되어서 저장이 안 되는 상태입니다 로그인/회원가입 후 cookie 탭을 확인해 보시면 노란색으로 쿠키가 넘어오는 것을 확인하실 수 있습니다