### PR TITLE
[#99]repactor: 코멘트 의견 반영으로 UI/UX 수정

### DIFF
--- a/src/components/quote/create/Calendar.tsx
+++ b/src/components/quote/create/Calendar.tsx
@@ -1,7 +1,17 @@
 "use client";
 
 import React, { useState } from "react";
-import { getDaysInMonth, addMonths, subMonths, startOfMonth, getDay, isToday, format } from "date-fns";
+import {
+  getDaysInMonth,
+  addMonths,
+  subMonths,
+  startOfMonth,
+  getDay,
+  isToday,
+  format,
+  isBefore,
+  startOfDay,
+} from "date-fns";
 import LeftArrowIcon from "@/assets/icon/arrow/icon-left.png";
 import RightArrowIcon from "@/assets/icon/arrow/icon-right.png";
 import LeftBigArrowIcon from "@/assets/icon/arrow/icon-left-lg.png";
@@ -13,10 +23,18 @@ import { ICalendarProps, IDateObj } from "@/types/quote";
 const Calendar: React.FC<ICalendarProps> = ({ value, onChange }) => {
   const [currentDate, setCurrentDate] = useState<Date>(new Date());
   const calendarMatrix = getCalendarMatrix(currentDate);
+  const today = startOfDay(new Date()); // 오늘 날짜 (시간 제거)
 
   const handlePrevMonth = () => setCurrentDate(subMonths(currentDate, 1));
   const handleNextMonth = () => setCurrentDate(addMonths(currentDate, 1));
-  const handleDateClick = (date: Date) => onChange(date);
+
+  const handleDateClick = (date: Date) => {
+    // 과거 날짜는 선택할 수 없음
+    if (isBefore(startOfDay(date), today)) {
+      return;
+    }
+    onChange(date);
+  };
 
   return (
     <div className="w-full pb-[2px]">
@@ -59,16 +77,26 @@ const Calendar: React.FC<ICalendarProps> = ({ value, onChange }) => {
             const isPrevOrNextMonth = dateObj.isOtherMonth;
             const isSelected = value && format(value, "yyyy-MM-dd") === format(dateObj.date, "yyyy-MM-dd");
             const isCurrentDay = isToday(dateObj.date);
+            const isPastDate = isBefore(startOfDay(dateObj.date), today);
 
             const cellClass = [
-              "basis-[14.28%] aspect-square flex items-center justify-center p-0 cursor-pointer select-none",
-              isPrevOrNextMonth ? "text-gray-300" : "text-gray-900",
-              isCurrentDay ? "font-black" : "",
+              "basis-[14.28%] aspect-square flex items-center justify-center p-0 select-none",
+              isPrevOrNextMonth
+                ? "text-gray-400 cursor-not-allowed"
+                : isPastDate
+                  ? "text-gray-300 cursor-not-allowed"
+                  : "cursor-pointer text-gray-900",
+              isCurrentDay && !isPastDate ? "font-black" : "",
               isSelected ? "bg-primary-400 rounded-full text-white" : "",
             ].join(" ");
 
             return (
-              <div key={j} onClick={() => handleDateClick(dateObj.date)} className={cellClass}>
+              <div
+                key={j}
+                onClick={() => handleDateClick(dateObj.date)}
+                className={cellClass}
+                title={isPrevOrNextMonth || isPastDate ? "과거 날짜는 선택할 수 없습니다" : ""}
+              >
                 {dateObj.day}
               </div>
             );

--- a/src/components/quote/create/ChooseAddressBtn.tsx
+++ b/src/components/quote/create/ChooseAddressBtn.tsx
@@ -6,7 +6,7 @@ const ChooseAddressBtn = ({ children, onClick, className = "" }: IChooseAddressB
     <button
       type="button"
       onClick={onClick}
-      className={`border-primary-400 text-primary-400 h-[54px] w-full items-center rounded-2xl border px-6 text-left text-base leading-[26px] font-semibold transition-colors focus:outline-none ${className}`}
+      className={`border-primary-400 text-primary-400 h-[54px] w-full cursor-pointer items-center rounded-2xl border px-6 text-left text-base leading-[26px] font-semibold transition-colors focus:outline-none ${className}`}
     >
       {children}
     </button>


### PR DESCRIPTION
## ✨ 작업 개요
- 이전 제작한 견적 요청 페이지 코멘트 의견 반영으로 UX 수정

## ✅ 주요 작업 내용
- 캘린더 이전날은 disabled 처리 후 색상을 다르게 처리함 
- 상단 견적요청 헤더 스크롤을 내려도 고정

## 🔄 관련 이슈
Closes #99

## 📸 스크린샷 (선택)
<img width="446" height="554" alt="image" src="https://github.com/user-attachments/assets/032637ac-f08a-4100-b71d-cbf190d4162c" />

## 🧪 테스트 방법 (선택)
- [ ] 화면 진입 시 데이터 정상 표시

## 📝 비고
- 추후 질문 -> 답변 -> 질문 -> 답변 식의 티키타카가 가능한 UI 고려중