### PR TITLE
[#101]feat: 번역기능 제작 및 견적 요청 페이지 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tanstack/react-query": "^5.81.5",
         "@tanstack/react-query-devtools": "^5.81.5",
         "clsx": "^2.1.1",
+        "date-fns": "^4.1.0",
         "jose": "^6.0.11",
         "lodash.throttle": "^4.1.1",
         "next": "15.3.4",
@@ -6580,6 +6581,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/dayjs": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@tanstack/react-query": "^5.81.5",
     "@tanstack/react-query-devtools": "^5.81.5",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "jose": "^6.0.11",
     "lodash.throttle": "^4.1.1",
     "next": "15.3.4",

--- a/src/components/common/LanguageSwitcher.tsx
+++ b/src/components/common/LanguageSwitcher.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useLanguageStore } from "@/stores/languageStore";
+import { useState } from "react";
+
+export const LanguageSwitcher = () => {
+  const { language, setLanguage, t } = useLanguageStore();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const languages = [
+    { code: "ko", name: t("한국어") },
+    { code: "en", name: t("English") },
+    { code: "zh", name: t("中文") },
+  ];
+
+  const handleLanguageChange = (languageCode: string) => {
+    setLanguage(languageCode as "ko" | "en" | "zh");
+    setIsOpen(false);
+  };
+
+  const currentLanguageName = languages.find((lang) => lang.code === language)?.name || "한국어";
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center space-x-2 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none"
+      >
+        <span>{currentLanguageName}</span>
+        <svg
+          className={`h-4 w-4 transition-transform ${isOpen ? "rotate-180" : ""}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 z-50 mt-2 w-32 rounded-md border border-gray-300 bg-white shadow-lg">
+          {languages.map((lang) => (
+            <button
+              key={lang.code}
+              onClick={() => handleLanguageChange(lang.code)}
+              className={`block w-full px-4 py-2 text-left text-sm hover:bg-gray-100 ${
+                language === lang.code ? "bg-blue-50 text-blue-700" : "text-gray-700"
+              }`}
+            >
+              {lang.name}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/common/Pagination/usePagination.ts
+++ b/src/components/common/Pagination/usePagination.ts
@@ -3,13 +3,12 @@ import { useMemo } from "react";
 export function usePagination(current: number, total: number, size: "sm" | "lg" = "sm") {
   const DOTS = "...";
   const siblingCount = 1;
-  const totalPageNumbers = 2 * siblingCount + 3; 
+  const totalPageNumbers = 2 * siblingCount + 3;
 
   return useMemo(() => {
     if (total <= 1) return [];
 
-    const range = (start: number, end: number) =>
-      Array.from({ length: end - start + 1 }, (_, i) => start + i);
+    const range = (start: number, end: number) => Array.from({ length: end - start + 1 }, (_, i) => start + i);
 
     // sm 사이즈
     if (size === "sm") {
@@ -85,4 +84,4 @@ export function usePagination(current: number, total: number, size: "sm" | "lg" 
 
     return range(1, total);
   }, [current, total, size]);
-} 
+}

--- a/src/components/common/gnb/GnbActions.tsx
+++ b/src/components/common/gnb/GnbActions.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import notification from "@/assets/icon/notification/icon-notification-lg.png";
 import { TDeviceType } from "@/types/deviceType";
 import Link from "next/link";
+import { LanguageSwitcher } from "@/components/common/LanguageSwitcher";
 
 interface IGnbActionsProps {
   userRole: TUserRole;
@@ -18,6 +19,9 @@ export const GnbActions = ({ userRole, deviceType, toggleSideMenu, isSideMenuOpe
 
   return (
     <div className="flex items-center gap-4">
+      {/* 언어 변경 버튼 */}
+      <LanguageSwitcher />
+
       {userRole === "guest" && deviceType === "desktop" && (
         <Link
           href="/userSignin"

--- a/src/components/common/modal/ModalContext.tsx
+++ b/src/components/common/modal/ModalContext.tsx
@@ -6,13 +6,13 @@ import type { IModalButton, IModalOptions } from "@/types/modal";
 import { create } from "zustand";
 
 // zustand store 정의
-interface ModalStore {
+interface IModalStore {
   modal: IModalOptions | null;
   open: (options: IModalOptions) => void;
   close: () => void;
 }
 
-export const useModalStore = create<ModalStore>((set) => ({
+export const useModalStore = create<IModalStore>((set) => ({
   modal: null,
   open: (options) => set({ modal: options }),
   close: () => set({ modal: null }),

--- a/src/components/quote/create/SpeechBubble.tsx
+++ b/src/components/quote/create/SpeechBubble.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ISpeechBubbleProps } from "@/types/quote";
+import { useLanguageStore } from "@/stores/languageStore";
 
 const baseBubbleClass =
   "lg:text-2lg inline-block max-w-full gap-2 rounded-3xl px-5 py-3 text-md leading-6 font-medium md:gap-4 mb-2 shadow-sm";
@@ -7,6 +8,7 @@ const baseBubbleClass =
 const SpeechBubble = ({ type, children, isLatest = false, onEdit }: ISpeechBubbleProps) => {
   const isQuestion = type === "question";
   const isAnswer = type === "answer";
+  const { t } = useLanguageStore();
 
   // answer 중에서 최신 질문 이후의 답변이 아니면 연한 배경
   const answerBg = isLatest ? "bg-primary-400 text-gray-50" : "bg-primary-100 text-primary-400";
@@ -32,7 +34,7 @@ const SpeechBubble = ({ type, children, isLatest = false, onEdit }: ISpeechBubbl
           className="hover:text-primary-400 mt-1 mr-2 text-xs leading-6 font-medium text-gray-500 underline transition-colors lg:mt-[6px] lg:text-base"
           onClick={onEdit}
         >
-          수정하기
+          {t("common.editAnswer")}
         </button>
       )}
     </div>

--- a/src/components/quote/create/card/AddressCard.tsx
+++ b/src/components/quote/create/card/AddressCard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { CircleTextLabel } from "@/components/common/chips/CircleTextLabel";
 import { IAddressCardProps } from "@/types/quote";
+import { useLanguageStore } from "@/stores/languageStore";
 
 // 공통 스타일 정의
 const styles = {
@@ -9,20 +10,21 @@ const styles = {
 };
 
 const AddressCard = ({ postalCode, roadAddress, jibunAddress, selected = false }: IAddressCardProps) => {
+  const { t } = useLanguageStore();
   return (
     <div
       className={`flex min-w-65 flex-col items-start gap-4 rounded-2xl border px-4 pt-5 pb-6 shadow-[2px_2px_10px_0px_rgba(224,224,224,0.20)] transition-colors ${selected ? "border-primary-400 bg-primary-100" : "border-border-light bg-white"} `}
     >
-      <span className={styles.postalCode}>{postalCode || "우편번호"}</span>
+      <span className={styles.postalCode}>{postalCode || t("quote.postalCode")}</span>
 
       <div className="flex w-full items-start gap-2">
-        <CircleTextLabel text="도로명" />
-        <span className={styles.addressText}>{roadAddress || "도로명 주소를 입력해주세요"}</span>
+        <CircleTextLabel text={t("quote.roadNameLabel")} />
+        <span className={styles.addressText}>{roadAddress || t("quote.roadAddressPlaceholder")}</span>
       </div>
 
       <div className="flex w-full items-start gap-2">
-        <CircleTextLabel text="지번" />
-        <span className={styles.addressText}>{jibunAddress || "지번 주소를 입력해주세요"}</span>
+        <CircleTextLabel text={t("quote.jibunLabel")} />
+        <span className={styles.addressText}>{jibunAddress || t("quote.jibunAddressPlaceholder")}</span>
       </div>
     </div>
   );

--- a/src/components/quote/create/card/AddressModal.tsx
+++ b/src/components/quote/create/card/AddressModal.tsx
@@ -4,10 +4,12 @@ import AddressCard from "./AddressCard";
 import { Button } from "@/components/common/button/Button";
 import { BaseInput } from "@/components/common/input/BaseInput";
 import { IAddressModalProps, IDaumAddress } from "@/types/quote";
+import { useLanguageStore } from "@/stores/languageStore";
 
 const AddressModal: React.FC<IAddressModalProps> = ({ onComplete, onClose }) => {
   const [base, setBase] = useState<IDaumAddress | null>(null);
   const [detail, setDetail] = useState("");
+  const { t } = useLanguageStore();
 
   const handleComplete = () => {
     if (base && detail) {
@@ -23,7 +25,7 @@ const AddressModal: React.FC<IAddressModalProps> = ({ onComplete, onClose }) => 
           <div className="mt-2">
             <BaseInput
               type="text"
-              placeholder="상세주소 (예: 101동 202호)"
+              placeholder={t("quote.detailAddressPlaceholder")}
               value={detail}
               onChange={(e) => setDetail(e.target.value)}
               inputClassName="w-full border rounded px-3 py-2"
@@ -48,7 +50,7 @@ const AddressModal: React.FC<IAddressModalProps> = ({ onComplete, onClose }) => 
           disabled={!base || !detail}
           onClick={handleComplete}
         >
-          선택완료
+          {t("quote.completeSelection")}
         </Button>
       )}
     </div>

--- a/src/components/quote/create/card/AddressSearchDaum.tsx
+++ b/src/components/quote/create/card/AddressSearchDaum.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import { IAddressSearchDaumProps, IDaumAddress, IDaumAddressData, IDaumPostcodeConstructor } from "@/types/quote";
+import { useLanguageStore } from "@/stores/languageStore";
 
 declare global {
   interface Window {
@@ -19,6 +20,7 @@ const loadDaumPostcodeScript = () => {
 };
 
 const AddressSearchDaum: React.FC<IAddressSearchDaumProps> = ({ onComplete }) => {
+  const { t } = useLanguageStore();
   useEffect(() => {
     if (!window.daum?.Postcode) {
       loadDaumPostcodeScript();
@@ -27,7 +29,7 @@ const AddressSearchDaum: React.FC<IAddressSearchDaumProps> = ({ onComplete }) =>
 
   const handleClick = () => {
     if (!window.daum?.Postcode) {
-      alert("주소 검색 스크립트가 아직 로드되지 않았습니다. 잠시 후 다시 시도해 주세요.");
+      alert(t("quote.addressSearchScriptNotLoaded"));
       return;
     }
     new window.daum.Postcode({
@@ -43,13 +45,16 @@ const AddressSearchDaum: React.FC<IAddressSearchDaumProps> = ({ onComplete }) =>
   };
 
   return (
-    <button
-      type="button"
-      onClick={handleClick}
-      className="border-primary-400 text-primary-400 h-[54px] w-full items-center rounded-2xl border px-6 text-left text-base leading-[26px] font-semibold transition-colors focus:outline-none"
-    >
-      주소 검색
-    </button>
+    <div>
+      <button
+        type="button"
+        onClick={handleClick}
+        className="border-primary-400 text-primary-400 h-[54px] w-full items-center rounded-2xl border px-6 text-left text-base leading-[26px] font-semibold transition-colors focus:outline-none"
+      >
+        {t("quote.searchAddress")}
+      </button>
+      <span className="text-md text-gray-500">{t("quote.serviceAvailableCountry")}</span>
+    </div>
   );
 };
 

--- a/src/components/quote/create/card/AddressSearchDaum.tsx
+++ b/src/components/quote/create/card/AddressSearchDaum.tsx
@@ -7,7 +7,7 @@ declare global {
     daum?: {
       Postcode: IDaumPostcodeConstructor;
     };
-  }
+  } // 실제 전역 객체
 }
 
 const loadDaumPostcodeScript = () => {

--- a/src/components/quote/create/sections/AddressSection.tsx
+++ b/src/components/quote/create/sections/AddressSection.tsx
@@ -7,16 +7,21 @@ import {
   addressSectionLastClass,
 } from "@/constant/quoteStyles";
 import { IAddress, IAddressSectionProps } from "@/types/quote";
+import { useLanguageStore } from "@/stores/languageStore";
 
-const AddressSection: React.FC<IAddressSectionProps> = ({ label, value, onClick }) => (
-  <div className={label === "출발지" ? addressSectionClass : addressSectionLastClass}>
-    <span className={sectionLabelClass}>{label}</span>
-    <ChooseAddressBtn className={addressBtnClass} onClick={onClick}>
-      {value.roadAddress
-        ? `${value.roadAddress}${value.detailAddress ? ` ${value.detailAddress}` : ""}`
-        : `${label} 선택하기`}
-    </ChooseAddressBtn>
-  </div>
-);
+const AddressSection: React.FC<IAddressSectionProps> = ({ label, value, onClick }) => {
+  const { t } = useLanguageStore();
+  const isDeparture = label === "departure";
+  return (
+    <div className={isDeparture ? addressSectionClass : addressSectionLastClass}>
+      <span className={sectionLabelClass}>{t(`quote.${label}`)}</span>
+      <ChooseAddressBtn className={addressBtnClass} onClick={onClick}>
+        {value.roadAddress
+          ? `${value.roadAddress}${value.detailAddress ? ` ${value.detailAddress}` : ""}`
+          : `${t(`quote.${label}`)} ${t("quote.selectAddress")}`}
+      </ChooseAddressBtn>
+    </div>
+  );
+};
 
 export default AddressSection;

--- a/src/components/quote/create/sections/MovingTypeSection.tsx
+++ b/src/components/quote/create/sections/MovingTypeSection.tsx
@@ -6,45 +6,50 @@ import MovingTypeSmall from "@/assets/img/etc/smallmove.png";
 import MovingTypeHome from "@/assets/img/etc/homemove.png";
 import MovingTypeOffice from "@/assets/img/etc/officemove.png";
 import { TMovingType, IMovingTypeSectionProps } from "@/types/quote";
+import { useLanguageStore } from "@/stores/languageStore";
 
-const MovingTypeSection: React.FC<IMovingTypeSectionProps> = ({ value, onSelect }) => (
-  <SpeechBubble type="question">
-    <div className="flex flex-col gap-4 lg:flex-row">
-      <MovingTypeCard
-        selected={value === "small"}
-        label="소형 이사"
-        description="원룸, 투룸, 20평대 미만"
-        image={
-          <div className="relative h-30 w-30">
-            <Image src={MovingTypeSmall} alt="소형 이사" fill className="object-contain" />
-          </div>
-        }
-        onClick={() => onSelect("small")}
-      />
-      <MovingTypeCard
-        selected={value === "home"}
-        label="가정 이사"
-        description="쓰리룸, 20평대 이상"
-        image={
-          <div className="relative h-30 w-30">
-            <Image src={MovingTypeHome} alt="가정 이사" fill className="object-contain" />
-          </div>
-        }
-        onClick={() => onSelect("home")}
-      />
-      <MovingTypeCard
-        selected={value === "office"}
-        label="사무실 이사"
-        description="사무실, 상업공간"
-        image={
-          <div className="relative h-30 w-30">
-            <Image src={MovingTypeOffice} alt="사무실 이사" fill className="object-contain" />
-          </div>
-        }
-        onClick={() => onSelect("office")}
-      />
-    </div>
-  </SpeechBubble>
-);
+const MovingTypeSection: React.FC<IMovingTypeSectionProps> = ({ value, onSelect }) => {
+  const { t } = useLanguageStore();
+
+  return (
+    <SpeechBubble type="question">
+      <div className="flex flex-col gap-4 lg:flex-row">
+        <MovingTypeCard
+          selected={value === "small"}
+          label={t("quote.movingTypes.small")}
+          description={t("quote.movingTypes.smallDesc")}
+          image={
+            <div className="relative h-30 w-30">
+              <Image src={MovingTypeSmall} alt={t("quote.movingTypes.small")} fill className="object-contain" />
+            </div>
+          }
+          onClick={() => onSelect("small")}
+        />
+        <MovingTypeCard
+          selected={value === "home"}
+          label={t("quote.movingTypes.home")}
+          description={t("quote.movingTypes.homeDesc")}
+          image={
+            <div className="relative h-30 w-30">
+              <Image src={MovingTypeHome} alt={t("quote.movingTypes.home")} fill className="object-contain" />
+            </div>
+          }
+          onClick={() => onSelect("home")}
+        />
+        <MovingTypeCard
+          selected={value === "office"}
+          label={t("quote.movingTypes.office")}
+          description={t("quote.movingTypes.officeDesc")}
+          image={
+            <div className="relative h-30 w-30">
+              <Image src={MovingTypeOffice} alt={t("quote.movingTypes.office")} fill className="object-contain" />
+            </div>
+          }
+          onClick={() => onSelect("office")}
+        />
+      </div>
+    </SpeechBubble>
+  );
+};
 
 export default MovingTypeSection;

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1,0 +1,68 @@
+{
+  "common": {
+    "language": "Language",
+    "korean": "한국어",
+    "english": "English",
+    "chinese": "中文",
+    "loading": "Loading...",
+    "error": "An error occurred",
+    "confirm": "Confirm",
+    "cancel": "Cancel",
+    "save": "Save",
+    "delete": "Delete",
+    "edit": "Edit",
+    "search": "Search",
+    "close": "Close",
+    "back": "Back",
+    "next": "Next",
+    "previous": "Previous",
+    "completeSelection": "Complete Selection",
+    "editAnswer": "Edit"
+  },
+  "quote": {
+    "title": "Quote Request",
+    "intro": "Just provide a few pieces of information and you can receive up to 5 quotes :)",
+    "movingTypeQuestion": "Please tell us the type of move.",
+    "dateQuestion": "Please tell us your moving date.",
+    "addressQuestion": "Please select the moving area.",
+    "departure": "Departure",
+    "arrival": "Arrival",
+    "confirmQuote": "Confirm Quote",
+    "movingTypes": {
+      "small": "Small Moving",
+      "smallDesc": "Studio, 2-room, under 20 pyeong",
+      "home": "Home Moving",
+      "homeDesc": "3-room, 20 pyeong or more",
+      "office": "Office Moving",
+      "officeDesc": "Office, commercial space",
+      "store": "Store Moving",
+      "piano": "Piano Moving",
+      "art": "Art Moving",
+      "storage": "Storage Moving"
+    },
+    "result": {
+      "movingType": "Moving Type",
+      "movingDate": "Moving Date",
+      "departure": "Departure",
+      "arrival": "Arrival"
+    },
+    "selectAddress": "Select",
+    "selectAddressTitle": "Please select {{place}}",
+    "searchAddress": "Search Address",
+    "detailAddressPlaceholder": "Detail address (e.g. Apt 101, Unit 202)",
+    "serviceAvailableCountry": "*Currently, the service is only available in South Korea.",
+    "addressSearchScriptNotLoaded": "The address search script has not loaded yet. Please try again in a moment.",
+    "postalCode": "Postal Code",
+    "roadNameLabel": "Road Name",
+    "jibunLabel": "Jibun",
+    "roadAddressPlaceholder": "Please enter the road name address",
+    "jibunAddressPlaceholder": "Please enter the jibun address"
+  },
+  "navigation": {
+    "home": "Home",
+    "quote": "Quote",
+    "services": "Services",
+    "about": "About",
+    "contact": "Contact"
+  }
+}

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -1,0 +1,68 @@
+{
+  "common": {
+    "language": "언어",
+    "korean": "한국어",
+    "english": "English",
+    "chinese": "中文",
+    "loading": "로딩 중...",
+    "error": "오류가 발생했습니다",
+    "confirm": "확인",
+    "cancel": "취소",
+    "save": "저장",
+    "delete": "삭제",
+    "edit": "수정",
+    "search": "검색",
+    "close": "닫기",
+    "back": "뒤로",
+    "next": "다음",
+    "previous": "이전"
+  },
+  "quote": {
+    "title": "견적요청",
+    "intro": "몇 가지 정보만 알려주시면 최대 5개의 견적을 받을 수 있어요 :)",
+    "movingTypeQuestion": "이사 종류를 알려주세요.",
+    "dateQuestion": "이사 예정일을 알려주세요.",
+    "addressQuestion": "이사 지역을 선택해주세요.",
+    "departure": "출발지",
+    "arrival": "도착지",
+    "confirmQuote": "견적 확정하기",
+    "movingTypes": {
+      "small": "소형 이사",
+      "smallDesc": "원룸, 투룸, 20평대 미만",
+      "home": "가정 이사",
+      "homeDesc": "쓰리룸, 20평대 이상",
+      "office": "사무실 이사",
+      "officeDesc": "사무실, 상업공간",
+      "store": "상가이사",
+      "piano": "피아노이사",
+      "art": "예술품이사",
+      "storage": "보관이사"
+    },
+    "result": {
+      "movingType": "이사 종류",
+      "movingDate": "이사 예정일",
+      "departure": "출발지",
+      "arrival": "도착지"
+    },
+    "selectAddress": "선택하기",
+    "selectAddressTitle": "{{place}}를 선택해주세요",
+    "searchAddress": "주소 검색",
+    "detailAddressPlaceholder": "상세주소 (예: 101동 202호)",
+    "completeSelection": "선택완료",
+    "postalCode": "우편번호",
+    "roadNameLabel": "도로명",
+    "jibunLabel": "지번",
+    "roadAddressPlaceholder": "도로명 주소를 입력해주세요",
+    "jibunAddressPlaceholder": "지번 주소를 입력해주세요",
+    "editAnswer": "수정하기"
+  },
+  "navigation": {
+    "home": "홈",
+    "quote": "견적",
+    "services": "서비스",
+    "about": "회사소개",
+    "contact": "문의"
+  },
+  "serviceAvailableCountry": "*현재 서비스 가능 국가는 대한민국입니다.",
+  "addressSearchScriptNotLoaded": "주소 검색 스크립트가 아직 로드되지 않았습니다. 잠시 후 다시 시도해 주세요."
+}

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -1,0 +1,68 @@
+{
+  "common": {
+    "language": "语言",
+    "korean": "한국어",
+    "english": "English",
+    "chinese": "中文",
+    "loading": "加载中...",
+    "error": "发生错误",
+    "confirm": "确认",
+    "cancel": "取消",
+    "save": "保存",
+    "delete": "删除",
+    "edit": "编辑",
+    "search": "搜索",
+    "close": "关闭",
+    "back": "返回",
+    "next": "下一步",
+    "previous": "上一步",
+    "completeSelection": "完成选择",
+    "editAnswer": "修改"
+  },
+  "quote": {
+    "title": "报价请求",
+    "intro": "只需提供一些信息，您就可以获得最多5个报价 :)",
+    "movingTypeQuestion": "请告诉我们搬家类型。",
+    "dateQuestion": "请告诉我们您的搬家日期。",
+    "addressQuestion": "请选择搬家区域。",
+    "departure": "出发地",
+    "arrival": "目的地",
+    "confirmQuote": "确认报价",
+    "movingTypes": {
+      "small": "小型搬家",
+      "smallDesc": "单间、两室、20坪以下",
+      "home": "家庭搬家",
+      "homeDesc": "三室、20坪以上",
+      "office": "办公室搬家",
+      "officeDesc": "办公室、商业空间",
+      "store": "商店搬家",
+      "piano": "钢琴搬家",
+      "art": "艺术品搬家",
+      "storage": "仓储搬家"
+    },
+    "result": {
+      "movingType": "搬家类型",
+      "movingDate": "搬家日期",
+      "departure": "出发地",
+      "arrival": "目的地"
+    },
+    "selectAddress": "选择",
+    "selectAddressTitle": "请选择{{place}}",
+    "searchAddress": "地址搜索",
+    "detailAddressPlaceholder": "详细地址（例如：101栋202室）",
+    "serviceAvailableCountry": "*目前仅在大韩民国提供服务。",
+    "addressSearchScriptNotLoaded": "地址搜索脚本尚未加载，请稍后再试。",
+    "postalCode": "邮政编码",
+    "roadNameLabel": "道路名",
+    "jibunLabel": "地段",
+    "roadAddressPlaceholder": "请输入道路名地址",
+    "jibunAddressPlaceholder": "请输入地段地址"
+  },
+  "navigation": {
+    "home": "首页",
+    "quote": "报价",
+    "services": "服务",
+    "about": "关于我们",
+    "contact": "联系我们"
+  }
+}

--- a/src/providers/QueryProvider.tsx
+++ b/src/providers/QueryProvider.tsx
@@ -38,11 +38,11 @@ function getQueryClient() {
   }
 }
 
-interface QueryProviderProps {
+interface IQueryProviderProps {
   children: ReactNode;
 }
 
-export default function QueryProvider({ children }: QueryProviderProps) {
+export default function QueryProvider({ children }: IQueryProviderProps) {
   const queryClient = getQueryClient();
 
   return (

--- a/src/stores/languageStore.ts
+++ b/src/stores/languageStore.ts
@@ -1,0 +1,25 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { getTranslation, type Language } from "@/utils/translations";
+
+interface ILanguageState {
+  language: Language;
+  setLanguage: (lang: Language) => void;
+  t: (key: string, params?: Record<string, string | number>) => string;
+}
+
+export const useLanguageStore = create<ILanguageState>()(
+  persist(
+    (set, get) => ({
+      language: "ko",
+      setLanguage: (lang: Language) => set({ language: lang }),
+      t: (key: string, params?: Record<string, string | number>) => {
+        const { language } = get();
+        return getTranslation(language, key, params);
+      },
+    }),
+    {
+      name: "language-storage",
+    },
+  ),
+);

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,23 +1,16 @@
 // 날짜 포맷 유틸리티 함수
-export const formatDateToKorean = (dateString: string): string => {
+export const formatDateByLanguage = (dateString: string, language: "ko" | "en" | "zh"): string => {
   if (!dateString) return "";
+  let locale = "ko-KR";
+  let options: Intl.DateTimeFormatOptions = { year: "numeric", month: "long", day: "numeric" };
 
-  return new Date(dateString).toLocaleDateString("ko-KR", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  });
-};
-
-export const getMovingTypeLabel = (type: string): string => {
-  switch (type) {
-    case "small":
-      return "소형 이사 (원룸, 투룸, 20평대 미만)";
-    case "home":
-      return "가정 이사 (쓰리룸, 20평대 이상)";
-    case "office":
-      return "사무실 이사 (사무실, 상업공간)";
-    default:
-      return "";
+  if (language === "en") {
+    locale = "en-US";
+    options = { year: "numeric", month: "long", day: "numeric" };
+  } else if (language === "zh") {
+    locale = "zh-CN";
+    options = { year: "numeric", month: "long", day: "numeric" };
   }
+
+  return new Date(dateString).toLocaleDateString(locale, options);
 };

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -1,0 +1,38 @@
+import ko from "@/messages/ko.json";
+import en from "@/messages/en.json";
+import zh from "@/messages/zh.json";
+
+export type Language = "ko" | "en" | "zh";
+
+export const translations = {
+  ko,
+  en,
+  zh,
+} as const;
+
+export const loadTranslations = (language: Language) => {
+  return translations[language];
+};
+
+export const getTranslation = (language: Language, key: string, params?: Record<string, string | number>) => {
+  const translation = translations[language];
+  const keys = key.split(".");
+
+  let result: any = translation;
+  for (const k of keys) {
+    if (result && typeof result === "object" && k in result) {
+      result = result[k];
+    } else {
+      return key; // 키가 없으면 원본 키 반환
+    }
+  }
+
+  if (typeof result === "string" && params) {
+    // {{key}} 치환
+    Object.entries(params).forEach(([k, v]) => {
+      result = result.replace(new RegExp(`{{${k}}}`, "g"), String(v));
+    });
+  }
+
+  return typeof result === "string" ? result : key;
+};


### PR DESCRIPTION
## ✨ 작업 개요
- 챌린지로 두었던 다국어 기능을 프로젝트 전반에 적용

## ✅ 주요 작업 내용
- `zustand` 기반 CSR 기반 다국어 스토어 구현
- 번역 데이터 JSON 형태로 분리
- 주요 UI에서 번역 함수 `t`를 사용
- 언어 변경 버튼 및 상태 관리 적용
- 견적 요청에서 하드 코딩된 텍스트 모두 번역 키로 교체
- 파라미터 치환, 버튼/placeholder/안내문 등 세부 UI까지 다국어 적용

## 🔄 관련 이슈
Closes #101

## 📸 스크린샷 (선택)
>
<img width="918" height="831" alt="스크린샷 2025-07-14 132558" src="https://github.com/user-attachments/assets/3f3daca6-40f7-40c8-927b-41431b924b97" />

<img width="925" height="860" alt="스크린샷 2025-07-14 132549" src="https://github.com/user-attachments/assets/a7a821fa-217f-4b49-8033-60b8e4d70fb9" />


## 🧪 테스트 방법 (선택)
- [ ] 화면 진입 시 데이터 정상 표시

## 📝 비고
- 달력 내부에 있는 요일도 번역 데이터를 따르도록 변경 예정
- `zustand`를 선택한 이유는 폴더 구조 컨벤션을 지키기 위해 사용 기존 `i18next`를 사용할 경우 폴더구조 변경이 불가피함 `locale` 디렉토리를 만들고 이 디렉토리 안에 폴더를 옮기는 과정이 필요한데 이 과정은 컨벤션에 맞지 않아 `zustand`로 구현함