### PR TITLE
[#117]feat: 찜하기 버튼 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.59.0",
+        "react-icon": "^1.0.0",
+        "react-icons": "^5.5.0",
         "zustand": "^5.0.6"
       },
       "devDependencies": {
@@ -5724,6 +5726,16 @@
         "@babel/core": "^7.11.0"
       }
     },
+    "node_modules/babel-runtime": {
+      "version": "5.8.38",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
+      "integrity": "sha512-KpgoA8VE/pMmNCrnEeeXqFG24TIH11Z3ZaimIhJWsin8EbfZy3WzFKUTIan10ZIDgRVvi9EkLbruJElJC9dRlg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "core-js": "^1.0.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -6321,6 +6333,14 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==",
+      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/core-js-compat": {
       "version": "3.43.0",
@@ -11871,6 +11891,25 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-icon": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/react-icon/-/react-icon-1.0.0.tgz",
+      "integrity": "sha512-VzSlpBHnLanVw79mOxyq98hWDi6DlxK9qPiZ1bAK6bLurMBCaxO/jjyYUrRx9+JGLc/NbnwOmyE/W5Qglbb2QA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-runtime": "^5.3.3",
+        "react": ">=0.12.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.59.0",
+    "react-icon": "^1.0.0",
+    "react-icons": "^5.5.0",
     "zustand": "^5.0.6"
   },
   "devDependencies": {

--- a/src/components/common/button/Favorite.tsx
+++ b/src/components/common/button/Favorite.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from "react";
+import { AiOutlineHeart, AiFillHeart } from "react-icons/ai";
+import FavoriteService, { IFavoriteStatus } from "../../../services/favoriteService";
+
+interface IFavoriteProps {
+  isFavorited: boolean;
+  favoriteCount: number;
+  moverId: number;
+  favoritedColor?: string;
+  unfavoritedColor?: string;
+  textColor?: string;
+  heartPosition?: "left" | "right";
+  onFavoriteChange?: (status: IFavoriteStatus) => void;
+  onClick?: () => void; // 부모 컴포넌트에서 전달받는 onClick
+}
+
+const Favorite = ({
+  isFavorited: initialIsFavorited,
+  favoriteCount: initialFavoriteCount,
+  moverId,
+  favoritedColor = "text-red-500",
+  unfavoritedColor = "text-gray-100",
+  textColor = "text-gray-500",
+  heartPosition = "left",
+  onFavoriteChange,
+  onClick,
+}: IFavoriteProps) => {
+  const [isFavorited, setIsFavorited] = useState(initialIsFavorited);
+  const [favoriteCount, setFavoriteCount] = useState(initialFavoriteCount);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleFavoriteClick = async () => {
+    if (isLoading) return; // 중복 클릭 방지
+
+    setIsLoading(true);
+    try {
+      let response;
+
+      if (isFavorited) {
+        // 찜하기 제거
+        response = await FavoriteService.removeFavorite(moverId);
+      } else {
+        // 찜하기 추가
+        response = await FavoriteService.addFavorite(moverId);
+      }
+
+      if (response.success && response.data) {
+        setIsFavorited(response.data.isFavorited);
+        setFavoriteCount(response.data.favoriteCount);
+
+        // 부모 컴포넌트에 상태 변경 알림
+        onFavoriteChange?.(response.data);
+
+        // 부모 컴포넌트의 onClick 호출
+        onClick?.();
+      }
+    } catch (error) {
+      console.error("찜하기 처리 오류:", error);
+      // 에러 발생 시 원래 상태로 되돌리기
+      setIsFavorited(initialIsFavorited);
+      setFavoriteCount(initialFavoriteCount);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const heartIcon = isFavorited ? (
+    <AiFillHeart className={favoritedColor} size={24} />
+  ) : (
+    <AiOutlineHeart className={unfavoritedColor} size={24} />
+  );
+
+  const countText = <span className={`text-md leading-6 font-normal ${textColor}`}>{favoriteCount}</span>;
+
+  return (
+    <button
+      className={`flex cursor-pointer items-center justify-center gap-[2px] ${isLoading ? "opacity-50" : ""}`}
+      onClick={handleFavoriteClick}
+      disabled={isLoading}
+    >
+      {heartPosition === "left" ? (
+        <>
+          {heartIcon}
+          {countText}
+        </>
+      ) : (
+        <>
+          {countText}
+          {heartIcon}
+        </>
+      )}
+    </button>
+  );
+};
+
+export default Favorite;

--- a/src/services/favoriteService.ts
+++ b/src/services/favoriteService.ts
@@ -1,0 +1,82 @@
+// 찜하기 관련 API 서비스
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5050";
+
+// API 응답 타입
+interface ApiResponse<T = any> {
+  success: boolean;
+  message: string;
+  data?: T;
+}
+
+// 찜하기 상태 타입
+export interface IFavoriteStatus {
+  isFavorited: boolean;
+  favoriteCount: number;
+}
+
+// 찜하기 요청 타입
+export interface IFavoriteRequest {
+  moverId: number;
+}
+
+// API 호출 헬퍼 함수
+const apiCall = async <T>(endpoint: string, options: RequestInit = {}): Promise<ApiResponse<T>> => {
+  try {
+    const token = localStorage.getItem("accessToken");
+    const url = `${API_BASE_URL}${endpoint}`;
+
+    console.log("찜하기 API 호출 정보:", {
+      url,
+      method: options.method || "GET",
+      headers: {
+        "Content-Type": "application/json",
+        ...(token && { Authorization: `Bearer ${token}` }),
+        ...options.headers,
+      },
+      body: options.body,
+    });
+
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        "Content-Type": "application/json",
+        ...(token && { Authorization: `Bearer ${token}` }),
+        ...options.headers,
+      },
+    });
+
+    console.log("찜하기 API 응답 상태:", response.status, response.statusText);
+
+    const data = await response.json();
+    console.log("찜하기 API 응답 데이터:", data);
+
+    if (!response.ok) {
+      throw new Error(data.message || "찜하기 API 호출에 실패했습니다.");
+    }
+
+    return data;
+  } catch (error) {
+    console.error("찜하기 API 호출 오류:", error);
+    throw error;
+  }
+};
+
+// 찜하기 서비스 클래스
+export class FavoriteService {
+  // 찜하기 추가
+  static async addFavorite(moverId: number): Promise<ApiResponse<IFavoriteStatus>> {
+    return apiCall<IFavoriteStatus>("/favorites", {
+      method: "POST",
+      body: JSON.stringify({ moverId }),
+    });
+  }
+
+  // 찜하기 제거
+  static async removeFavorite(moverId: number): Promise<ApiResponse<IFavoriteStatus>> {
+    return apiCall<IFavoriteStatus>(`/favorites/${moverId}`, {
+      method: "DELETE",
+    });
+  }
+}
+
+export default FavoriteService;


### PR DESCRIPTION
## ✨ 작업 개요
- 리액트 아이콘을 사용하여 찜하기 UI 제작 및 백엔드 연동

## ✅ 주요 작업 내용
- UI 제작
- 백엔드 연동

## 🔄 관련 이슈


Closes #117

## 📸 스크린샷 (선택)
> <img width="436" height="254" alt="스크린샷 2025-07-16 135307" src="https://github.com/user-attachments/assets/9ca75a53-1bd8-4421-b058-52ad35708ea9" />

## 🧪 테스트 방법 (선택)
- [ ] test 페이지에서 정상 동작 확인

## 📝 비고
- 각 조회 API에서 isLiked 필드가 있어야 해당 페이지에서 하트의 색상을 보일 수 있게 구현할 수 있음 (get 메소드를 만들 수 있는데 get 메소드 사용보다 필드 하나 추가하는게 사용 용량이 더 적기 때문에) 
- 이미지를 사용하지 않은 이유는 이미지 깨짐 이슈 발생으로 아이콘으로 해결
- 아이콘으로 어떤 색상이든 부모 컴포넌트에서 받아서 사용할 수 있도록 제작
- API를 컴포넌트 내부에서 사용한 이유는 이 컴포넌트를 여러 페이지에서 사용하게 될텐데 부모 컴포넌트에서 사용하게 되면 DX 측면에서 공통된 코드를 작성하기 때문에 비효율적이라고 판단