### PR TITLE
[#95] Feat/notification 알림 기능 구현.

### DIFF
--- a/src/app/notification/page.tsx
+++ b/src/app/notification/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Button } from "@/components/common/button/Button";
+import { createTestNotification } from "@/lib/api/notification.api";
+
+const notificationTestPage = () => {
+  const handleActionCreate = () => {
+    createTestNotification();
+  };
+  return (
+    <div>
+      {/* 테스트용 액션 생성 버튼 */}
+      <Button onClick={handleActionCreate} variant="solid" rounded="rounded-xl" width="w-22" height="h-8">
+        알림 생성
+      </Button>
+    </div>
+  );
+};
+
+export default notificationTestPage;

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,13 +1,15 @@
-import { ModalProvider } from "@/components/common/modal/ModalContext";
 import QueryProvider from "@/providers/QueryProvider";
 import AuthProvider from "@/providers/AuthProvider";
-import React from "react";
+import { ModalProvider } from "@/components/common/modal/ModalContext";
+import NotificationSSEProvider from "@/providers/NotificationSSEProvider";
 
 const Providers = ({ children }: { children: React.ReactNode }) => {
   return (
     <QueryProvider>
       <AuthProvider>
-        <ModalProvider>{children}</ModalProvider>
+        <ModalProvider>
+          <NotificationSSEProvider>{children}</NotificationSSEProvider>
+        </ModalProvider>
       </AuthProvider>
     </QueryProvider>
   );

--- a/src/components/common/dropdown/UserActionDropdown.tsx
+++ b/src/components/common/dropdown/UserActionDropdown.tsx
@@ -9,6 +9,7 @@ interface IUserActionDropdownProps {
   isOpen?: boolean;
   children?: React.ReactNode;
   name?: string;
+  triggerRef?: React.RefObject<HTMLElement | null>;
 }
 
 // 공통 드롭다운 컨테이너 컴포넌트
@@ -54,7 +55,7 @@ const DropdownHeader = ({
   </div>
 );
 
-const UserActionDropdown = ({ type, onClose, isOpen, children, name }: IUserActionDropdownProps) => {
+const UserActionDropdown = ({ type, onClose, isOpen, children, name, triggerRef }: IUserActionDropdownProps) => {
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   // ESC 키로 닫기
@@ -77,7 +78,13 @@ const UserActionDropdown = ({ type, onClose, isOpen, children, name }: IUserActi
   // 외부 클릭으로 닫기
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node) && isOpen) {
+      const target = event.target as Node;
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(target) &&
+        triggerRef?.current &&
+        !triggerRef.current.contains(target)
+      ) {
         onClose?.();
       }
     };
@@ -89,12 +96,14 @@ const UserActionDropdown = ({ type, onClose, isOpen, children, name }: IUserActi
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
-  }, [isOpen, onClose]);
+  }, [isOpen, onClose, triggerRef]);
+
+  if (!isOpen) return null;
 
   return (
     <div className="" ref={dropdownRef}>
       {type === "alert" ? (
-        <DropdownContainer className="w-72 lg:w-[359px]" rounded="rounded-24">
+        <DropdownContainer className="absolute -right-30 w-78 md:-right-7 lg:w-[359px]" rounded="rounded-24">
           <DropdownHeader title="알림" onClose={onClose} />
           {children}
         </DropdownContainer>

--- a/src/components/common/gnb/GnbActions.tsx
+++ b/src/components/common/gnb/GnbActions.tsx
@@ -1,4 +1,6 @@
-import React from "react";
+"use client";
+
+import React, { useRef, useState, useEffect } from "react";
 import profile from "@/assets/icon/auth/icon-profile-lg.png";
 import Image from "next/image";
 import notification from "@/assets/icon/notification/icon-notification-lg.png";
@@ -6,6 +8,9 @@ import { TDeviceType } from "@/types/deviceType";
 import Link from "next/link";
 import { LanguageSwitcher } from "@/components/common/LanguageSwitcher";
 import { TUserRole } from "@/types/user.types";
+import NotificationList from "@/components/notification/NotificationList";
+import UserActionDropdown from "../dropdown/UserActionDropdown";
+import { useNotificationStore } from "@/stores/notificationStore";
 
 interface IGnbActionsProps {
   userRole: TUserRole;
@@ -16,6 +21,20 @@ interface IGnbActionsProps {
 }
 
 export const GnbActions = ({ userRole, userName, deviceType, toggleSideMenu, isSideMenuOpen }: IGnbActionsProps) => {
+  const [isNotificationOpen, setIsNotificationOpen] = useState(false);
+  const notificationButtonRef = useRef<HTMLButtonElement>(null);
+  const hasUnread = useNotificationStore((state) => state.hasUnread);
+  const fetchNotifications = useNotificationStore((state) => state.fetchNotifications);
+
+  const handleNotificationClick = () => {
+    setIsNotificationOpen((prev) => !prev);
+  };
+
+  useEffect(() => {
+    // 최초 1회만 전체 알림의 hasUnread, total 등 받아오기
+    fetchNotifications(1, 0);
+  }, [fetchNotifications]);
+
   return (
     <div className="flex items-center gap-4">
       {/* 언어 변경 버튼 */}
@@ -33,14 +52,27 @@ export const GnbActions = ({ userRole, userName, deviceType, toggleSideMenu, isS
       {userRole !== "GUEST" && (
         <>
           {/* 알림 버튼 */}
-          <button className="hover:text-black-400 cursor-pointer p-2 text-gray-400 transition-colors" aria-label="알림">
+          <div className="hover:text-black-400 cursor-pointer p-2 text-gray-400 transition-colors" aria-label="알림">
             <div className="relative h-6 w-6">
-              {/* 알림 아이콘 자리 - 이미지로 교체 예정 */}
-              <Image src={notification} alt="알림" width={24} height={24} />
-              {/* 알림 뱃지 (필요시) */}
-              <div className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-red-500"></div>
+              <button
+                ref={notificationButtonRef}
+                onClick={handleNotificationClick}
+                className="cursor-pointer"
+                aria-label="알림"
+              >
+                <Image src={notification} alt="알림" width={24} height={24} />
+                {hasUnread && <div className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-red-500"></div>}
+              </button>
+              <UserActionDropdown
+                type="alert"
+                onClose={() => setIsNotificationOpen(false)}
+                isOpen={isNotificationOpen}
+                triggerRef={notificationButtonRef}
+              >
+                <NotificationList />
+              </UserActionDropdown>
             </div>
-          </button>
+          </div>
 
           {/* 프로필 버튼 */}
           <button

--- a/src/components/notification/NotificationList.tsx
+++ b/src/components/notification/NotificationList.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import React, { useEffect, useCallback, useRef } from "react";
+import { useInView } from "react-intersection-observer";
+import { useNotificationStore } from "@/stores/notificationStore";
+import DOMPurify from "dompurify";
+import parse from "html-react-parser";
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+import "dayjs/locale/ko";
+import Link from "next/link";
+
+dayjs.extend(relativeTime);
+dayjs.locale("ko");
+
+export default function NotificationList() {
+  const { notifications, hasMore, fetchNotifications } = useNotificationStore();
+  const limit = 4;
+  const loadingRef = useRef(false);
+
+  useEffect(() => {
+    fetchNotifications(limit, 0);
+  }, []);
+
+  const { ref, inView } = useInView({ threshold: 0.2 });
+
+  const loadMore = useCallback(async () => {
+    if (loadingRef.current) return;
+    loadingRef.current = true;
+    await fetchNotifications(limit, notifications.length);
+    loadingRef.current = false;
+  }, [fetchNotifications, notifications.length, limit]);
+
+  useEffect(() => {
+    if (inView && hasMore && !loadingRef.current) {
+      loadMore();
+    }
+  }, [inView, hasMore, loadMore]);
+
+  if (notifications.length === 0) {
+    return (
+      <div className="flex w-full items-center justify-center">
+        <div className="p-2 text-center text-gray-400">아직 알림이 없어요!</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-black-400 max-h-[215px] w-full overflow-y-auto">
+      {notifications.map((notification, idx) => (
+        notification.actionUrl ? (
+          <Link
+            key={`${notification.id}-${idx}`}
+            href={notification.actionUrl}
+            className={`flex cursor-pointer flex-col items-start p-4 hover:bg-gray-50 ${
+              idx !== notifications.length - 1 ? "border-b border-gray-200" : ""
+            }`}
+          >
+            <div className="text-sm break-words">{parse(DOMPurify.sanitize(notification.title))}</div>
+            <div className="mt-1 text-xs text-gray-400">{dayjs(notification.createdAt).fromNow()}</div>
+          </Link>
+        ) : (
+          <div
+            key={`${notification.id}-${idx}`}
+            className={`flex flex-col items-start p-4 ${
+              idx !== notifications.length - 1 ? "border-b border-gray-200" : ""
+            }`}
+          >
+            <div className="text-sm break-words">{parse(DOMPurify.sanitize(notification.title))}</div>
+            <div className="mt-1 text-xs text-gray-400">{dayjs(notification.createdAt).fromNow()}</div>
+          </div>
+        )
+      ))}
+      {hasMore && <div ref={ref} style={{ height: 40 }} />}
+      {!hasMore && <div className="py-2 text-center text-xs text-gray-400">모든 알림을 불러왔습니다.</div>}
+    </div>
+  );
+}

--- a/src/components/notification/NotificationList.tsx
+++ b/src/components/notification/NotificationList.tsx
@@ -8,7 +8,10 @@ import parse from "html-react-parser";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import "dayjs/locale/ko";
-import Link from "next/link";
+import { readNotification } from "@/lib/api/notification.api";
+import { useRouter } from "next/navigation";
+import { INotification } from "@/types/notification.types";
+
 
 dayjs.extend(relativeTime);
 dayjs.locale("ko");
@@ -17,6 +20,7 @@ export default function NotificationList() {
   const { notifications, hasMore, fetchNotifications } = useNotificationStore();
   const limit = 4;
   const loadingRef = useRef(false);
+  const router = useRouter();
 
   useEffect(() => {
     fetchNotifications(limit, 0);
@@ -37,6 +41,16 @@ export default function NotificationList() {
     }
   }, [inView, hasMore, loadMore]);
 
+  // 알림 클릭 핸들러
+  const handleClick = async (notification: INotification) => {
+    try {
+      await readNotification(notification.id);
+    } catch (e) {
+      // 에러 무시하고 이동
+    }
+    router.push(notification.actionUrl);
+  };
+
   if (notifications.length === 0) {
     return (
       <div className="flex w-full items-center justify-center">
@@ -49,16 +63,16 @@ export default function NotificationList() {
     <div className="text-black-400 max-h-[215px] w-full overflow-y-auto">
       {notifications.map((notification, idx) => (
         notification.actionUrl ? (
-          <Link
+          <div
             key={`${notification.id}-${idx}`}
-            href={notification.actionUrl}
             className={`flex cursor-pointer flex-col items-start p-4 hover:bg-gray-50 ${
               idx !== notifications.length - 1 ? "border-b border-gray-200" : ""
             }`}
+            onClick={() => handleClick(notification)}
           >
             <div className="text-sm break-words">{parse(DOMPurify.sanitize(notification.title))}</div>
             <div className="mt-1 text-xs text-gray-400">{dayjs(notification.createdAt).fromNow()}</div>
-          </Link>
+          </div>
         ) : (
           <div
             key={`${notification.id}-${idx}`}

--- a/src/lib/api/notification.api.ts
+++ b/src/lib/api/notification.api.ts
@@ -1,9 +1,10 @@
 import { INotification } from "@/types/notification.types";
+import { getTokenFromCookie } from "@/utils/auth";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL;
 
 const getAccessToken = async () => {
-  const accessToken = await localStorage.getItem("accessToken");
+  const accessToken = await getTokenFromCookie();
   return accessToken;
 };
 

--- a/src/lib/api/notification.api.ts
+++ b/src/lib/api/notification.api.ts
@@ -60,3 +60,18 @@ export async function readAllNotifications() {
   if (!res.ok) throw new Error("전체 알림 읽음 처리 실패");
   return res.json();
 }
+
+// 테스트용 알림 생성
+export async function createTestNotification() {
+  const accessToken = await getAccessToken();
+  const res = await fetch(`${API_URL}/actions/test`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+  if (!res.ok) throw new Error("테스트 알림 생성 실패");
+  return res.json();
+}

--- a/src/lib/api/notification.api.ts
+++ b/src/lib/api/notification.api.ts
@@ -1,0 +1,61 @@
+import { INotification } from "@/types/notification.types";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+const getAccessToken = async () => {
+  const accessToken = await localStorage.getItem("accessToken");
+  return accessToken;
+};
+
+export interface NotificationApiResponse {
+  success: boolean;
+  message: string;
+  data: {
+    items: INotification[];
+    total: number;
+    limit: number;
+    offset: number;
+    hasUnread: boolean;
+  };
+}
+
+// 알림 목록 조회
+export async function getNotifications(limit = 3, offset = 0): Promise<NotificationApiResponse> {
+  const res = await fetch(`${API_URL}/notifications?limit=${limit}&offset=${offset}`, {
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${await getAccessToken()}`,
+    },
+  });
+  if (!res.ok) throw new Error("알림 목록 조회 실패");
+  return res.json();
+}
+
+// 개별 알림 읽음 처리
+export async function readNotification(notificationId: string) {
+  const res = await fetch(`${API_URL}/notifications/${notificationId}/read`, {
+    method: "PATCH",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${await getAccessToken()}`,
+    },
+  });
+  if (!res.ok) throw new Error("알림 읽음 처리 실패");
+  return res.json();
+}
+
+// 전체 알림 읽음 처리
+export async function readAllNotifications() {
+  const res = await fetch(`${API_URL}/notifications/read-all`, {
+    method: "PATCH",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${await getAccessToken()}`,
+    },
+  });
+  if (!res.ok) throw new Error("전체 알림 읽음 처리 실패");
+  return res.json();
+}

--- a/src/providers/NotificationSSEProvider.tsx
+++ b/src/providers/NotificationSSEProvider.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useEffect } from "react";
+import { useNotificationStore } from "@/stores/notificationStore";
+
+export default function NotificationSSEProvider({ children }: { children: React.ReactNode }) {
+  const connectSSE = useNotificationStore((state) => state.connectSSE);
+  const disconnectSSE = useNotificationStore((state) => state.disconnectSSE);
+
+  useEffect(() => {
+    const token = localStorage.getItem("accessToken");
+    if (token) connectSSE(token);
+    return () => {
+      disconnectSSE();
+    };
+  }, [connectSSE, disconnectSSE]);
+
+  return <>{children}</>;
+}

--- a/src/stores/notificationStore.ts
+++ b/src/stores/notificationStore.ts
@@ -1,0 +1,133 @@
+import { create } from "zustand";
+import { EventSourcePolyfill } from "event-source-polyfill";
+import { INotification } from "@/types/notification.types";
+import { getNotifications, readAllNotifications, readNotification } from "@/lib/api/notification.api";
+
+interface INotificationState {
+  notifications: INotification[];
+  hasMore: boolean;
+  hasUnread: boolean;
+  total: number;
+  setNotifications: (notis: INotification[]) => void;
+  addNotification: (noti: INotification) => void;
+  connectSSE: (token: string) => void;
+  disconnectSSE: () => void;
+  fetchNotifications: (limit?: number, offset?: number) => Promise<void>;
+  markAsRead: (id: string) => Promise<void>;
+  markAllAsRead: () => Promise<void>;
+}
+
+let eventSource: EventSourcePolyfill | null = null;
+let reconnectAttempts = 0;
+let reconnectTimeout: NodeJS.Timeout | null = null;
+let disconnectTimer: NodeJS.Timeout | null = null;
+
+const MAX_RECONNECT_ATTEMPTS = 10;
+const RECONNECT_INTERVAL = 5000; // 5초
+const AUTO_DISCONNECT_TIME = 60 * 60 * 1000; // 1시간
+
+export const useNotificationStore = create<INotificationState>((set, get) => ({
+  notifications: [],
+  hasMore: true,
+  hasUnread: false,
+  total: 0,
+  setNotifications: (notis) => set({ notifications: notis }),
+  addNotification: (noti) => set((state) => ({ notifications: [noti, ...state.notifications] })),
+  connectSSE: (token: string) => {
+    // 기존 연결 종료 및 타이머 초기화
+    if (eventSource) eventSource.close();
+    if (reconnectTimeout) {
+      clearTimeout(reconnectTimeout);
+      reconnectTimeout = null;
+    }
+    if (disconnectTimer) {
+      clearTimeout(disconnectTimer);
+      disconnectTimer = null;
+    }
+    // SSE 연결
+    eventSource = new EventSourcePolyfill(`${process.env.NEXT_PUBLIC_API_URL}/sse/notification`, {
+      headers: { Authorization: `Bearer ${token}` },
+      withCredentials: true,
+    });
+    // 자동 종료 타이머(1시간)
+    disconnectTimer = setTimeout(() => {
+      get().disconnectSSE();
+    }, AUTO_DISCONNECT_TIME);
+    // 메시지 수신
+    eventSource.onmessage = function (event) {
+      try {
+        const data = JSON.parse(event.data);
+        get().addNotification(data);
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    // 에러 발생 시 재연결
+    eventSource.onerror = function () {
+      if (eventSource) {
+        eventSource.close();
+        eventSource = null;
+      }
+      if (reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
+        reconnectAttempts++;
+        reconnectTimeout = setTimeout(() => {
+          get().connectSSE(token);
+        }, RECONNECT_INTERVAL);
+      } else {
+        // 최대 재연결 시도 초과 시 자동 종료
+        get().disconnectSSE();
+      }
+    };
+    // 연결 성공 시 재시도 횟수 초기화
+    eventSource.onopen = function () {
+      reconnectAttempts = 0;
+      // 타임아웃 재설정
+      if (disconnectTimer) {
+        clearTimeout(disconnectTimer);
+      }
+      disconnectTimer = setTimeout(() => {
+        get().disconnectSSE();
+      }, AUTO_DISCONNECT_TIME);
+    };
+  },
+  disconnectSSE: () => {
+    if (eventSource) {
+      eventSource.close();
+      eventSource = null;
+    }
+    if (reconnectTimeout) {
+      clearTimeout(reconnectTimeout);
+      reconnectTimeout = null;
+    }
+    if (disconnectTimer) {
+      clearTimeout(disconnectTimer);
+      disconnectTimer = null;
+    }
+    reconnectAttempts = 0;
+  },
+  // --- API 연동 부분 ---
+  fetchNotifications: async (limit = 3, offset = 0) => {
+    const res = await getNotifications(limit, offset);
+    set((state) => {
+      const newNotifications = offset === 0 ? res.data.items : [...state.notifications, ...res.data.items];
+      return {
+        notifications: newNotifications,
+        hasMore: newNotifications.length < res.data.total,
+        hasUnread: res.data.hasUnread,
+        total: res.data.total,
+      };
+    });
+  },
+  markAsRead: async (id: string) => {
+    await readNotification(id);
+    set((state) => ({
+      notifications: state.notifications.map((n) => (n.id === id ? { ...n, unread: false } : n)),
+    }));
+  },
+  markAllAsRead: async () => {
+    await readAllNotifications();
+    set((state) => ({
+      notifications: state.notifications.map((n) => (n.unread ? { ...n, unread: false } : n)),
+    }));
+  },
+}));

--- a/src/types/notification.types.ts
+++ b/src/types/notification.types.ts
@@ -1,0 +1,7 @@
+export interface INotification {
+  id: string;
+  title: string;
+  actionUrl: string;
+  createdAt: string;
+  unread: boolean;
+}


### PR DESCRIPTION
## ✨ 작업 개요
SSE 로 실시간 알림을 구현.
헤더바 내의 알림 아이콘을 클릭시 아이콘 아래에 모달로 알림 리스트가 무한스크롤로 나열되고.
해당 알림을 누르면 읽음 처리가 되며 해당 페이지로 이동.

## ✅ 작업 항목
- [x] 알림 목록 조회 API 구현.
- [x] 개별 알림 읽음 처리 API 구현.
- [x] 전체 알림 읽음 처리 API 구현. -> 챌린지용.
- [x] 헤더바 알림 아이콘 밑에 드롭다운 형태 모달 열리게 공용 컴포넌트 사용 구현.
- [x] 무한스크롤 기능 구현.
- [x] 알림 클릭시 해당 URL 받아서 읽음 처리 후 이동 구현..
- [x] 새로운 알림 (아직 읽지 않은) 존재시 알림 붉은불 들어오게 구현.
- [x] 알림 생성 테스트를 위해 테스트용 API 및 알림 페이지 생성하여 테스트 완료.


## ✅ 주요 작업 내용
- SSE 연결을 위한 프로바이더 구현.
- 알림을 전역관리 하기 위해 zustand로 notificationStore 구현.
- gnb 내에 알림 종모양 바로 밑에 드롭다운 형태로 알림을 보여주기 위해 드롭다운 공용 컴포넌트 사용.
- 리스트를 무한스크롤로 알림창 내에서 구현하기 위해 intersection observer 라이브러리 사용.
- 리스트 가져오기와 읽음 처리 API 구현.
- 테스트를 위해 알림 페이지를 임시로 작성하여 버튼 클릭시 테스트용 알림 생성되게 구현.
- 유저가 테스트용 버튼을 누르면 모든 기사님들에게 새로운 견적이 등록됐다고 알림이 가도록 구현하여 SSE 확인. 
- 반응형 구현.

## 🔄 관련 이슈
Closes #95 - 알림 구현.
#92 - 분석.

## 📸 스크린샷 (선택)
<img width="1348" height="404" alt="알림 예시 웹" src="https://github.com/user-attachments/assets/fec4f34d-4892-4aab-8707-054fc5943ed9" />
<img width="878" height="383" alt="알림 예시 태블릿" src="https://github.com/user-attachments/assets/1891af74-8413-4d4e-a90f-f423ef27ca36" />
<img width="538" height="386" alt="알림 예시 모바일" src="https://github.com/user-attachments/assets/e60ef6d7-6ce5-4c04-b36c-b22a86422213" />

## 🧪 테스트 방법 (선택)
- [ ] 알림 페이지에 접속해서 알림 생성 버튼 클릭시 모든 기사님 알림이 실시간으로 추가. 
- [ ] 헤더 내에 종모양 클릭시 알림창이 열리고 3개씩 받아 오도록 무한스크롤 기능 가능.

## 📝 비고
- 현재는 견적이 등록되면 모든 기사님에게 알림이 가지만 리팩토링을 거쳐 해당되는 기사님에게만 가도록 수정 예정.