### PR TITLE
[#73] refactor: 기본정보수정 리팩토링 및 passwordinput 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7989,10 +7989,11 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",

--- a/src/components/common/input/PasswordInput.tsx
+++ b/src/components/common/input/PasswordInput.tsx
@@ -33,7 +33,12 @@ export const PasswordInput = ({
 
   const toggleIcon = (
     <button
-      onClick={() => setVisible(!visible)}
+      type="button"
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setVisible(!visible);
+      }}
       className="flex h-6 w-6 items-center justify-center"
       aria-label={!visible ? "비밀번호 숨기기" : "비밀번호 보이기"}
     >

--- a/src/pageComponents/moverMyPage/edit/EditPage.tsx
+++ b/src/pageComponents/moverMyPage/edit/EditPage.tsx
@@ -96,7 +96,7 @@ const EditPage = () => {
       <div className="mx-auto flex w-full max-w-[560px] flex-col gap-12 rounded-3xl bg-white px-4 py-10 lg:max-w-[1200px]">
         <div className="mb-4 text-2xl font-bold !text-black text-black">기본정보 수정</div>
         <FormProvider {...form}>
-          <form onSubmit={handleSubmit(onSubmit)} className="grid grid-cols-1 gap-x-12 gap-y-8 lg:grid-cols-2">
+          <form onSubmit={handleSubmit(onSubmit)} className="grid grid-cols-1 gap-x-40 gap-y-8 lg:grid-cols-2">
             <div className="flex flex-col gap-8">
               <div className="flex flex-col gap-4">
                 <div className="text-base leading-relaxed font-semibold text-zinc-800 lg:text-lg">이름</div>
@@ -112,7 +112,7 @@ const EditPage = () => {
                 <div className="text-base leading-relaxed font-semibold text-zinc-800 lg:text-lg">이메일</div>
                 <TextInput
                   name="email"
-                  inputClassName="w-full lg:w-[500px] p-3.5 bg-white rounded-2xl outline outline-1 outline-offset-[-1px] outline-neutral-200 text-base text-neutral-400 !text-black pointer-events-none bg-gray-100"
+                  inputClassName="w-full lg:w-[500px] p-3.5 bg-white rounded-2xl outline outline-1 outline-offset-[-1px] outline-neutral-200 text-base text-[#999999] pointer-events-none bg-gray-100"
                   wrapperClassName="w-full max-w-[560px] sm:!w-full lg:max-w-none lg:w-[500px]"
                   placeholder="이메일을 입력해주세요"
                 />
@@ -142,9 +142,8 @@ const EditPage = () => {
                       return true;
                     },
                   }}
-                  inputClassName="w-full lg:w-[500px] p-3.5 bg-white rounded-2xl outline outline-1 outline-offset-[-1px] outline-neutral-200 text-base !text-black placeholder-neutral-400 pr-16 lg:pr-16"
-                  errorClassName=""
-                  wrapperClassName="w-full max-w-[560px] sm:!w-full lg:max-w-none lg:w-[500px] w-full relative px-0"
+                  inputClassName="w-full lg:w-[500px] h-[54px] lg:h-[64px] p-3.5 bg-white rounded-2xl outline outline-1 outline-offset-[-1px] outline-neutral-200 text-base !text-black placeholder-neutral-400 pr-16"
+                  wrapperClassName="w-full max-w-[560px] sm:!w-full lg:max-w-none lg:w-[500px] relative"
                 />
               </div>
               <div className="flex flex-col gap-4">
@@ -161,8 +160,8 @@ const EditPage = () => {
                       return true;
                     },
                   }}
-                  inputClassName="w-full lg:w-[500px] p-3.5 bg-white rounded-2xl outline outline-1 outline-offset-[-1px] outline-neutral-200 text-base !text-black placeholder-neutral-400 pr-16 lg:pr-16"
-                  wrapperClassName="w-full max-w-[560px] sm:!w-full lg:max-w-none lg:w-[500px] w-full relative px-0"
+                  inputClassName="w-full lg:w-[500px] h-[54px] lg:h-[64px] p-3.5 bg-white rounded-2xl outline outline-1 outline-offset-[-1px] outline-neutral-200 text-base !text-black placeholder-neutral-400 pr-16"
+                  wrapperClassName="w-full max-w-[560px] sm:!w-full lg:max-w-none lg:w-[500px] relative"
                 />
               </div>
               <div className="flex flex-col gap-4">
@@ -179,8 +178,8 @@ const EditPage = () => {
                       return true;
                     },
                   }}
-                  inputClassName="w-full lg:w-[500px] p-3.5 bg-white rounded-2xl outline outline-1 outline-offset-[-1px] outline-neutral-200 text-base !text-black placeholder-neutral-400 pr-16 lg:pr-16"
-                  wrapperClassName="w-full max-w-[560px] sm:!w-full lg:max-w-none lg:w-[500px] w-full relative px-0"
+                  inputClassName="w-full lg:w-[500px] h-[54px] lg:h-[64px] p-3.5 bg-white rounded-2xl outline outline-1 outline-offset-[-1px] outline-neutral-200 text-base !text-black placeholder-neutral-400 pr-16"
+                  wrapperClassName="w-full max-w-[560px] sm:!w-full lg:max-w-none lg:w-[500px] relative"
                 />
               </div>
             </div>
@@ -214,7 +213,7 @@ const EditPage = () => {
         }
         @media (min-width: 1024px) {
           .relative [class*="absolute"][class*="right-"] {
-            right: 1.25rem !important; /* right-4 */
+            right: 1.25rem !important;
           }
         }
       `}</style>


### PR DESCRIPTION
## ✨ 작업 개요
- 기본정보수정 리팩토링 및 passwordinput 수정

## ✅ 주요 작업 내용
-  기사님 기본 정보 수정 리팩토링
- 이름,이메일,전화번호 input에 로그인한 유저의 정보 자동으로 채워짐
- Passwordinput 컴포넌트 수정 -> type="button" 추가
- 이메일input -> 글씨 색상 변경
- 눈모양 아이콘 위치 변경

## 🔄 관련 이슈
Closes #73 

## 📸 스크린샷 (선택)
<img width="1652" height="912" alt="image" src="https://github.com/user-attachments/assets/745438e4-092a-4144-be18-787f87b9f0d7" />


## 🧪 테스트 방법 (선택)


## 📝 비고
- 추후에 글로벌 css에 있는 내용으로 리팩토링 예정