### PR TITLE
[#135] feat : 토큰 재발급 로직 적용 및 재발급 사용을 위한 래핑 함수 구현

### DIFF
--- a/src/lib/actions/auth.actions.ts
+++ b/src/lib/actions/auth.actions.ts
@@ -21,7 +21,7 @@ export async function setServerSideTokens(accessToken: string) {
   cookieStore.set("accessToken", accessToken, {
     path: "/",
     maxAge: accessTokenExpiresIn,
-    sameSite: "strict",
+    sameSite: "none",
   });
 }
 
@@ -37,7 +37,7 @@ export async function updateAccessToken(accessToken: string) {
   cookieStore.set("accessToken", accessToken, {
     path: "/",
     maxAge: accessTokenExpiresIn,
-    sameSite: "strict",
+    sameSite: "none",
   });
 }
 
@@ -46,7 +46,6 @@ export async function clearServerSideTokens() {
 
   // 액세스 토큰 삭제
   cookieStore.delete("accessToken");
-
   // 리프레시 토큰 삭제
   cookieStore.delete("refreshToken");
 

--- a/src/lib/api/auth.api.ts
+++ b/src/lib/api/auth.api.ts
@@ -62,6 +62,26 @@ const authApi = {
 
     return responseData;
   },
+
+  // 리프레쉬 토큰을 사용한 토큰 갱신
+  refreshToken: async () => {
+    const response = await fetch(`${API_URL}/auth/refresh-token`, {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+      credentials: "include",
+    });
+
+    const responseData = await response.json();
+
+    // 토큰 갱신 성공 시 쿠키에 저장
+    if (responseData.success) {
+      setTokensToCookie(responseData.accessToken);
+    }
+
+    return responseData;
+  },
 };
 
 export default authApi;

--- a/src/lib/api/fetcher.api.ts
+++ b/src/lib/api/fetcher.api.ts
@@ -1,0 +1,55 @@
+import { getTokenFromCookie, setTokensToCookie } from "@/utils/auth";
+import authApi from "./auth.api";
+
+// TODO? : 제네릭 any 타입을 각 api 호출의 반환 타입으로 변경? (이게 구조적으로 맞는 방식)
+// TODO? : 그러나 파일이 많아지고 비용이 듬
+
+// 토큰 만료 시 재발급 로직 구현
+// 요청 api 토큰 인가 실패 -> 리프레쉬 토큰으로 재발급 로직 실행 -> 성공시 이전 요청 재시도
+// 만약 리프레쉬 토큰 만료시 로그아웃 처리
+export const fetchWithAuth = async <T = any>(input: RequestInfo, init: RequestInit = {}, retry = true): Promise<T> => {
+  const accessToken = await getTokenFromCookie();
+
+  const res = await fetch(input, {
+    ...init,
+    headers: {
+      ...(init.headers || {}),
+      Authorization: `Bearer ${accessToken}`,
+    },
+    credentials: "include", // refreshToken 쿠키 필요 시 포함
+  });
+
+  // 401 Unauthorized → accessToken 만료 가능성
+  if (res.status === 401 && retry) {
+    const refreshed = await authApi.refreshToken();
+
+    if (refreshed?.accessToken) {
+      // 👉 새 토큰 쿠키에도 저장
+      setTokensToCookie(refreshed.accessToken);
+
+      // 👉 Authorization 헤더에 새 토큰 명시 후 재시도
+      return fetchWithAuth<T>(
+        input,
+        {
+          ...init,
+          headers: {
+            ...(init.headers || {}),
+            Authorization: `Bearer ${refreshed.accessToken}`,
+          },
+        },
+        false, // 재귀 방지
+      );
+    }
+
+    // 🔒 refreshToken도 만료 → 로그아웃 처리
+    authApi.logout();
+    throw new Error("로그인이 만료되었습니다.");
+  }
+
+  if (!res.ok) {
+    const error = await res.json();
+    throw new Error(error.message || "API 요청 실패");
+  }
+
+  return res.json();
+};

--- a/src/lib/api/user.api.ts
+++ b/src/lib/api/user.api.ts
@@ -1,4 +1,5 @@
 import { getTokenFromCookie, setTokensToCookie } from "@/utils/auth";
+import { fetchWithAuth } from "./fetcher.api";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL;
 
@@ -34,12 +35,9 @@ interface IMoverProfileInput {
 
 const userApi = {
   getUser: async () => {
-    const response = await fetch(`${API_URL}/users`, {
-      headers: {
-        Authorization: `Bearer ${await getAccessToken()}`,
-      },
-    });
-    return response.json();
+    const response = await fetchWithAuth(`${API_URL}/users`);
+
+    return response;
   },
 
   uploadFilesToS3: async (file: File) => {
@@ -70,10 +68,8 @@ const userApi = {
 
   // 프로필 조회
   getProfile: async () => {
-    const response = await fetch(`${API_URL}/users/profile`, {
-      headers: { Authorization: `Bearer ${await getAccessToken()}` },
-    });
-    return response.json();
+    const response = await fetchWithAuth(`${API_URL}/users/profile`);
+    return response;
   },
 
   // 프로필 등록


### PR DESCRIPTION
## ✨ 작업 개요

- JWT 슬라이딩 세션 방식을 적용한 **토큰 재발급 로직**을 구현하였습니다.
- `fetcher.api.ts` 라는 wrapper를 통해 모든 API 요청을 감싸고, 토큰 만료 상황에서 재발급 → 재시도 흐름을 자동화하였습니다.

## ✅ 주요 작업 내용

- [x] `fetcher.api.ts` 파일 생성 및 공통 fetch 래퍼 구현
- [x] 엑세스 토큰 만료 시, 리프레쉬 토큰 기반 재발급 요청 처리
- [x] 재발급 성공 시 최초 요청 재시도 / 실패 시 로그아웃 처리
- [x] 서버 응답 상태 코드에 따른 분기 처리 (401, 403 등)
- [x] 재발급 조건: 리프레쉬 토큰의 남은 만료 기간이 5일 이하일 경우 같이 갱신

## 🔄 관련 이슈

Closes #135

## 📎 참고 자료 (선택)
### 토큰 재발급 로직 호출전
<img width="1918" height="389" alt="재발급전" src="https://github.com/user-attachments/assets/fa2f0b76-fdd8-4010-bb3d-c9511721ed64" />

### 토큰 재발급 전 
<img width="1581" height="207" alt="토큰 재발급 전" src="https://github.com/user-attachments/assets/57ea6f62-c97b-45e8-9d02-6c7eba73c325" />

### 토큰 재발급 로직 호출 후
<img width="1921" height="451" alt="재발급 로직 실행" src="https://github.com/user-attachments/assets/64ff99da-d669-44a5-9b27-7045551c3177" />

### 토큰 재발급 로직 호출 후
<img width="1908" height="298" alt="토큰 재발급 후" src="https://github.com/user-attachments/assets/15405451-8d1f-4640-bdae-64165968150d" />


## 🧪 테스트 방법 (선택)

- [ ] 엑세스 토큰 만료 상태에서 API 호출 시 자동으로 토큰 재발급되는지 확인
- [ ] 리프레쉬 토큰도 만료된 경우, 자동으로 로그아웃 처리되는지 확인
- [ ] 리프레쉬 토큰의 만료 기간이 5일 이하일 때 같이 재발급되는지 확인 (이는 서버쪽 로컬 테스트로, 만료값 변경으로 테스트 가능)
- [ ] 실패 시 1회만 재시도되며 이후엔 로그아웃되는지 확인

## 📝 비고

- 엑세스 토큰 유효 기간: **30분**
- 리프레쉬 토큰 유효 기간: **2주**
- 리프레쉬 토큰 재발급 조건: **남은 유효기간 5일 이하**
