### PR TITLE
[#58] feat : 구글/카카오/네이버 소셜 로그인 구현

### DIFF
--- a/src/app/[locale]/(auth)/callback/page.tsx
+++ b/src/app/[locale]/(auth)/callback/page.tsx
@@ -1,0 +1,6 @@
+import AuthCallback from "@/pageComponents/auth/callback/AuthCallback";
+
+// /auth/callback 페이지 (보호되지 않음)
+export default function page() {
+  return <AuthCallback />;
+}

--- a/src/lib/api/auth.api.ts
+++ b/src/lib/api/auth.api.ts
@@ -94,6 +94,12 @@ const authApi = {
     // 전체 페이지를 카카오 OAuth로 리디렉션
     window.location.href = `${API_URL}/auth/kakao?userType=${userType}`;
   },
+
+  // 네이버 로그인 (페이지 리디렉션 방식)
+  naverLogin: async (userType: "CUSTOMER" | "MOVER"): Promise<void> => {
+    // 전체 페이지를 네이버 OAuth로 리디렉션
+    window.location.href = `${API_URL}/auth/naver?userType=${userType}`;
+  },
 };
 
 export default authApi;

--- a/src/lib/api/auth.api.ts
+++ b/src/lib/api/auth.api.ts
@@ -82,6 +82,12 @@ const authApi = {
 
     return responseData;
   },
+
+  // 구글 로그인 (페이지 리디렉션 방식)
+  googleLogin: async (userType: "CUSTOMER" | "MOVER"): Promise<void> => {
+    // 전체 페이지를 구글 OAuth로 리디렉션
+    window.location.href = `${API_URL}/auth/google?userType=${userType}`;
+  },
 };
 
 export default authApi;

--- a/src/lib/api/auth.api.ts
+++ b/src/lib/api/auth.api.ts
@@ -88,6 +88,12 @@ const authApi = {
     // 전체 페이지를 구글 OAuth로 리디렉션
     window.location.href = `${API_URL}/auth/google?userType=${userType}`;
   },
+
+  // 카카오 로그인 (페이지 리디렉션 방식)
+  kakaoLogin: async (userType: "CUSTOMER" | "MOVER"): Promise<void> => {
+    // 전체 페이지를 카카오 OAuth로 리디렉션
+    window.location.href = `${API_URL}/auth/kakao?userType=${userType}`;
+  },
 };
 
 export default authApi;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -47,6 +47,8 @@ export async function middleware(request: NextRequest) {
     }
   }
 
+  console.log("accessToken", accessToken);
+
   const isAuthenticated = !!accessToken;
 
   // ✅ 루트 경로 접근 제어 (next-intl보다 먼저 처리)
@@ -87,8 +89,13 @@ export async function middleware(request: NextRequest) {
     (pathname.startsWith("/estimate") && !pathname.startsWith("/estimateRequest")) ||
     pathname.startsWith("/moverMyPage");
 
-  // ✅ 프로필 등록 강제 이동
+  // ✅ 일반 로그인 프로필 등록 강제 이동
   if (isProtectedRoute && !hasProfile && pathname !== "/profile/register") {
+    return NextResponse.redirect(new URL(withLocalePrefix("/profile/register", locale), request.url));
+  }
+
+  // ✅ 소셜 로그인 프로필 등록 강제 이동
+  if (!hasProfile && (pathname === "/searchMover" || pathname === "/estimate/received")) {
     return NextResponse.redirect(new URL(withLocalePrefix("/profile/register", locale), request.url));
   }
 

--- a/src/pageComponents/auth/callback/AuthCallback.tsx
+++ b/src/pageComponents/auth/callback/AuthCallback.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { setTokensToCookie } from "@/utils/auth";
+import { useEffect } from "react";
+
+// /auth/callback 페이지 (보호되지 않음)
+export default function AuthCallback() {
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const accessToken = params.get("accessToken");
+
+    if (accessToken) {
+      // 쿠키에 토큰 저장
+      setTokensToCookie(accessToken);
+
+      // 적절한 페이지로 리디렉션
+      window.location.href = "/profile/register";
+    }
+  }, []);
+
+  return <div>로그인 처리 중...</div>;
+}

--- a/src/pageComponents/auth/callback/AuthCallback.tsx
+++ b/src/pageComponents/auth/callback/AuthCallback.tsx
@@ -18,5 +18,41 @@ export default function AuthCallback() {
     }
   }, []);
 
-  return <div>로그인 처리 중...</div>;
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-orange-50 via-white to-red-50">
+      <div className="text-center">
+        {/* 파동 애니메이션 */}
+        <div className="relative mx-auto mb-8 flex h-32 w-32 items-center justify-center">
+          {/* 중앙 원 */}
+          <div className="absolute h-8 w-8 animate-pulse rounded-full bg-[#f9502e]"></div>
+
+          {/* 파동 효과 - 1번째 원 */}
+          <div className="absolute h-16 w-16 animate-ping rounded-full border-2 border-[#f9502e] opacity-75"></div>
+
+          {/* 파동 효과 - 2번째 원 */}
+          <div
+            className="absolute h-24 w-24 animate-ping rounded-full border-2 border-orange-400 opacity-50"
+            style={{ animationDelay: "0.5s" }}
+          ></div>
+
+          {/* 파동 효과 - 3번째 원 */}
+          <div
+            className="absolute h-32 w-32 animate-ping rounded-full border-2 border-orange-300 opacity-25"
+            style={{ animationDelay: "1s" }}
+          ></div>
+        </div>
+
+        {/* 로딩 텍스트 */}
+        <div className="space-y-2">
+          <h2 className="text-2xl font-bold text-gray-800">로그인 처리 중</h2>
+          <div className="flex items-center justify-center space-x-1">
+            <div className="h-2 w-2 animate-bounce rounded-full bg-[#f9502e]"></div>
+            <div className="h-2 w-2 animate-bounce rounded-full bg-[#f9502e]" style={{ animationDelay: "0.1s" }}></div>
+            <div className="h-2 w-2 animate-bounce rounded-full bg-[#f9502e]" style={{ animationDelay: "0.2s" }}></div>
+          </div>
+          <p className="mt-4 text-gray-600">잠시만 기다려주세요...</p>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/pageComponents/auth/moverSignin/MoverSigninPage.tsx
+++ b/src/pageComponents/auth/moverSignin/MoverSigninPage.tsx
@@ -18,7 +18,7 @@ import { validationRules } from "@/utils/validators";
 import { useModal } from "@/components/common/modal/ModalContext";
 
 const MoverSigninPage = () => {
-  const { login, isLoading } = useAuth();
+  const { login, isLoading, googleLogin } = useAuth();
   const deviceType = useWindowWidth();
   const { open, close } = useModal();
 
@@ -129,7 +129,14 @@ const MoverSigninPage = () => {
         <div className="flex w-full flex-col items-center justify-center gap-8">
           <span className="text-black-200 text-lg">SNS 계정으로 간편 로그인</span>
           <div className="flex items-center gap-8">
-            <Image src={google} alt="google" width={62} height={62} className="cursor-pointer" />
+            <Image
+              src={google}
+              alt="google"
+              width={62}
+              height={62}
+              className="cursor-pointer"
+              onClick={() => googleLogin("MOVER")}
+            />
             <Image src={kakao} alt="kakao" width={62} height={62} className="cursor-pointer" />
             <Image src={naver} alt="naver" width={62} height={62} className="cursor-pointer" />
           </div>

--- a/src/pageComponents/auth/moverSignin/MoverSigninPage.tsx
+++ b/src/pageComponents/auth/moverSignin/MoverSigninPage.tsx
@@ -18,7 +18,7 @@ import { validationRules } from "@/utils/validators";
 import { useModal } from "@/components/common/modal/ModalContext";
 
 const MoverSigninPage = () => {
-  const { login, isLoading, googleLogin, kakaoLogin } = useAuth();
+  const { login, isLoading, googleLogin, kakaoLogin, naverLogin } = useAuth();
   const deviceType = useWindowWidth();
   const { open, close } = useModal();
 
@@ -145,7 +145,14 @@ const MoverSigninPage = () => {
               className="cursor-pointer"
               onClick={() => kakaoLogin("MOVER")}
             />
-            <Image src={naver} alt="naver" width={62} height={62} className="cursor-pointer" />
+            <Image
+              src={naver}
+              alt="naver"
+              width={62}
+              height={62}
+              className="cursor-pointer"
+              onClick={() => naverLogin("MOVER")}
+            />
           </div>
 
           {deviceType === "tablet" && (

--- a/src/pageComponents/auth/moverSignin/MoverSigninPage.tsx
+++ b/src/pageComponents/auth/moverSignin/MoverSigninPage.tsx
@@ -18,7 +18,7 @@ import { validationRules } from "@/utils/validators";
 import { useModal } from "@/components/common/modal/ModalContext";
 
 const MoverSigninPage = () => {
-  const { login, isLoading, googleLogin } = useAuth();
+  const { login, isLoading, googleLogin, kakaoLogin } = useAuth();
   const deviceType = useWindowWidth();
   const { open, close } = useModal();
 
@@ -44,7 +44,7 @@ const MoverSigninPage = () => {
     try {
       if (isLoading) return;
       const response = await login(email, password, "MOVER");
-      if (response.success === false) {
+      if (response.status !== 200) {
         open({
           title: "로그인 실패",
           children: <div>{response.message}</div>,
@@ -137,7 +137,14 @@ const MoverSigninPage = () => {
               className="cursor-pointer"
               onClick={() => googleLogin("MOVER")}
             />
-            <Image src={kakao} alt="kakao" width={62} height={62} className="cursor-pointer" />
+            <Image
+              src={kakao}
+              alt="kakao"
+              width={62}
+              height={62}
+              className="cursor-pointer"
+              onClick={() => kakaoLogin("MOVER")}
+            />
             <Image src={naver} alt="naver" width={62} height={62} className="cursor-pointer" />
           </div>
 

--- a/src/pageComponents/auth/moverSignup/MoverSignupPage.tsx
+++ b/src/pageComponents/auth/moverSignup/MoverSignupPage.tsx
@@ -19,7 +19,7 @@ import { useModal } from "@/components/common/modal/ModalContext";
 
 const MoverSignupPage = () => {
   const deviceType = useWindowWidth();
-  const { isLoading, signUp, googleLogin, kakaoLogin } = useAuth();
+  const { isLoading, signUp, googleLogin, kakaoLogin, naverLogin } = useAuth();
   const { open, close } = useModal();
 
   const form = useForm<ISignUpFormValues>({
@@ -200,7 +200,14 @@ const MoverSignupPage = () => {
               className="cursor-pointer"
               onClick={() => kakaoLogin("MOVER")}
             />
-            <Image src={naver} alt="naver" width={62} height={62} className="cursor-pointer" />
+            <Image
+              src={naver}
+              alt="naver"
+              width={62}
+              height={62}
+              className="cursor-pointer"
+              onClick={() => naverLogin("MOVER")}
+            />
           </div>
 
           {deviceType === "tablet" && (

--- a/src/pageComponents/auth/moverSignup/MoverSignupPage.tsx
+++ b/src/pageComponents/auth/moverSignup/MoverSignupPage.tsx
@@ -13,14 +13,13 @@ import naver from "@/assets/icon/auth/icon-login-naver-lg.png";
 import moverAvatarLg from "@/assets/img/mascot/mover-avatartion-lg.png";
 import { useWindowWidth } from "@/hooks/useWindowWidth";
 import { ISignUpFormValues } from "@/types/auth";
-import authApi from "@/lib/api/auth.api";
 import { useAuth } from "@/providers/AuthProvider";
 import { validationRules } from "@/utils/validators";
 import { useModal } from "@/components/common/modal/ModalContext";
 
 const MoverSignupPage = () => {
   const deviceType = useWindowWidth();
-  const { isLoading, signUp } = useAuth();
+  const { isLoading, signUp, googleLogin } = useAuth();
   const { open, close } = useModal();
 
   const form = useForm<ISignUpFormValues>({
@@ -185,7 +184,14 @@ const MoverSignupPage = () => {
         <div className="flex w-full flex-col items-center justify-center gap-8">
           <span className="text-black-200 text-lg">SNS 계정으로 간편 로그인</span>
           <div className="flex items-center gap-8">
-            <Image src={google} alt="google" width={62} height={62} className="cursor-pointer" />
+            <Image
+              src={google}
+              alt="google"
+              width={62}
+              height={62}
+              className="cursor-pointer"
+              onClick={() => googleLogin("MOVER")}
+            />
             <Image src={kakao} alt="kakao" width={62} height={62} className="cursor-pointer" />
             <Image src={naver} alt="naver" width={62} height={62} className="cursor-pointer" />
           </div>

--- a/src/pageComponents/auth/moverSignup/MoverSignupPage.tsx
+++ b/src/pageComponents/auth/moverSignup/MoverSignupPage.tsx
@@ -19,7 +19,7 @@ import { useModal } from "@/components/common/modal/ModalContext";
 
 const MoverSignupPage = () => {
   const deviceType = useWindowWidth();
-  const { isLoading, signUp, googleLogin } = useAuth();
+  const { isLoading, signUp, googleLogin, kakaoLogin } = useAuth();
   const { open, close } = useModal();
 
   const form = useForm<ISignUpFormValues>({
@@ -56,7 +56,7 @@ const MoverSignupPage = () => {
       if (isLoading) return;
       const response = await signUp(signUpData);
 
-      if (!response.success) {
+      if (response.status !== 200) {
         open({
           title: "회원가입 실패",
           children: <div>{response.message}</div>,
@@ -192,7 +192,14 @@ const MoverSignupPage = () => {
               className="cursor-pointer"
               onClick={() => googleLogin("MOVER")}
             />
-            <Image src={kakao} alt="kakao" width={62} height={62} className="cursor-pointer" />
+            <Image
+              src={kakao}
+              alt="kakao"
+              width={62}
+              height={62}
+              className="cursor-pointer"
+              onClick={() => kakaoLogin("MOVER")}
+            />
             <Image src={naver} alt="naver" width={62} height={62} className="cursor-pointer" />
           </div>
 

--- a/src/pageComponents/auth/userSignin/UserSigninPage.tsx
+++ b/src/pageComponents/auth/userSignin/UserSigninPage.tsx
@@ -19,7 +19,7 @@ import { validationRules } from "@/utils/validators";
 import { useModal } from "@/components/common/modal/ModalContext";
 
 const UserSigninPage = () => {
-  const { login, isLoading, googleLogin, kakaoLogin } = useAuth();
+  const { login, isLoading, googleLogin, kakaoLogin, naverLogin } = useAuth();
   const deviceType = useWindowWidth();
   const { open, close } = useModal();
   const t = useTranslations("auth");
@@ -148,7 +148,14 @@ const UserSigninPage = () => {
               className="cursor-pointer"
               onClick={() => kakaoLogin("CUSTOMER")}
             />
-            <Image src={naver} alt="naver" width={62} height={62} className="cursor-pointer" />
+            <Image
+              src={naver}
+              alt="naver"
+              width={62}
+              height={62}
+              className="cursor-pointer"
+              onClick={() => naverLogin("CUSTOMER")}
+            />
           </div>
 
           {deviceType === "tablet" && (

--- a/src/pageComponents/auth/userSignin/UserSigninPage.tsx
+++ b/src/pageComponents/auth/userSignin/UserSigninPage.tsx
@@ -19,7 +19,7 @@ import { validationRules } from "@/utils/validators";
 import { useModal } from "@/components/common/modal/ModalContext";
 
 const UserSigninPage = () => {
-  const { login, isLoading } = useAuth();
+  const { login, isLoading, googleLogin } = useAuth();
   const deviceType = useWindowWidth();
   const { open, close } = useModal();
   const t = useTranslations("auth");
@@ -46,7 +46,7 @@ const UserSigninPage = () => {
     try {
       if (isLoading) return;
       const response = await login(email, password, "CUSTOMER");
-      if (response.status === 401) {
+      if (response.success === false) {
         open({
           title: t("loginFailed"),
           children: <div>{response.message}</div>,
@@ -131,7 +131,14 @@ const UserSigninPage = () => {
         <div className="flex w-full flex-col items-center justify-center gap-8">
           <span className="text-black-200 text-lg">SNS 계정으로 간편 로그인</span>
           <div className="flex items-center gap-8">
-            <Image src={google} alt="google" width={62} height={62} className="cursor-pointer" />
+            <Image
+              src={google}
+              alt="google"
+              width={62}
+              height={62}
+              className="cursor-pointer"
+              onClick={() => googleLogin("CUSTOMER")}
+            />
             <Image src={kakao} alt="kakao" width={62} height={62} className="cursor-pointer" />
             <Image src={naver} alt="naver" width={62} height={62} className="cursor-pointer" />
           </div>

--- a/src/pageComponents/auth/userSignin/UserSigninPage.tsx
+++ b/src/pageComponents/auth/userSignin/UserSigninPage.tsx
@@ -19,7 +19,7 @@ import { validationRules } from "@/utils/validators";
 import { useModal } from "@/components/common/modal/ModalContext";
 
 const UserSigninPage = () => {
-  const { login, isLoading, googleLogin } = useAuth();
+  const { login, isLoading, googleLogin, kakaoLogin } = useAuth();
   const deviceType = useWindowWidth();
   const { open, close } = useModal();
   const t = useTranslations("auth");
@@ -46,7 +46,8 @@ const UserSigninPage = () => {
     try {
       if (isLoading) return;
       const response = await login(email, password, "CUSTOMER");
-      if (response.success === false) {
+
+      if (response.status !== 200) {
         open({
           title: t("loginFailed"),
           children: <div>{response.message}</div>,
@@ -139,7 +140,14 @@ const UserSigninPage = () => {
               className="cursor-pointer"
               onClick={() => googleLogin("CUSTOMER")}
             />
-            <Image src={kakao} alt="kakao" width={62} height={62} className="cursor-pointer" />
+            <Image
+              src={kakao}
+              alt="kakao"
+              width={62}
+              height={62}
+              className="cursor-pointer"
+              onClick={() => kakaoLogin("CUSTOMER")}
+            />
             <Image src={naver} alt="naver" width={62} height={62} className="cursor-pointer" />
           </div>
 

--- a/src/pageComponents/auth/userSignup/UserSignupPage.tsx
+++ b/src/pageComponents/auth/userSignup/UserSignupPage.tsx
@@ -19,7 +19,7 @@ import { useModal } from "@/components/common/modal/ModalContext";
 
 const UserSignupPage = () => {
   const deviceType = useWindowWidth();
-  const { isLoading, signUp } = useAuth();
+  const { isLoading, signUp, googleLogin } = useAuth();
   const { open, close } = useModal();
 
   const form = useForm<ISignUpFormValues>({
@@ -183,7 +183,14 @@ const UserSignupPage = () => {
         <div className="flex w-full flex-col items-center justify-center gap-8">
           <span className="text-black-200 text-lg">SNS 계정으로 간편 로그인</span>
           <div className="flex items-center gap-8">
-            <Image src={google} alt="google" width={62} height={62} className="cursor-pointer" />
+            <Image
+              src={google}
+              alt="google"
+              width={62}
+              height={62}
+              className="cursor-pointer"
+              onClick={() => googleLogin("CUSTOMER")}
+            />
             <Image src={kakao} alt="kakao" width={62} height={62} className="cursor-pointer" />
             <Image src={naver} alt="naver" width={62} height={62} className="cursor-pointer" />
           </div>

--- a/src/pageComponents/auth/userSignup/UserSignupPage.tsx
+++ b/src/pageComponents/auth/userSignup/UserSignupPage.tsx
@@ -19,7 +19,7 @@ import { useModal } from "@/components/common/modal/ModalContext";
 
 const UserSignupPage = () => {
   const deviceType = useWindowWidth();
-  const { isLoading, signUp, googleLogin } = useAuth();
+  const { isLoading, signUp, googleLogin, kakaoLogin } = useAuth();
   const { open, close } = useModal();
 
   const form = useForm<ISignUpFormValues>({
@@ -55,7 +55,7 @@ const UserSignupPage = () => {
     try {
       if (isLoading) return;
       const response = await signUp(signUpData);
-      if (!response.success) {
+      if (response.status !== 200) {
         open({
           title: "회원가입 실패",
           children: <div>{response.message}</div>,
@@ -191,7 +191,14 @@ const UserSignupPage = () => {
               className="cursor-pointer"
               onClick={() => googleLogin("CUSTOMER")}
             />
-            <Image src={kakao} alt="kakao" width={62} height={62} className="cursor-pointer" />
+            <Image
+              src={kakao}
+              alt="kakao"
+              width={62}
+              height={62}
+              className="cursor-pointer"
+              onClick={() => kakaoLogin("CUSTOMER")}
+            />
             <Image src={naver} alt="naver" width={62} height={62} className="cursor-pointer" />
           </div>
 

--- a/src/pageComponents/auth/userSignup/UserSignupPage.tsx
+++ b/src/pageComponents/auth/userSignup/UserSignupPage.tsx
@@ -19,7 +19,7 @@ import { useModal } from "@/components/common/modal/ModalContext";
 
 const UserSignupPage = () => {
   const deviceType = useWindowWidth();
-  const { isLoading, signUp, googleLogin, kakaoLogin } = useAuth();
+  const { isLoading, signUp, googleLogin, kakaoLogin, naverLogin } = useAuth();
   const { open, close } = useModal();
 
   const form = useForm<ISignUpFormValues>({
@@ -199,7 +199,14 @@ const UserSignupPage = () => {
               className="cursor-pointer"
               onClick={() => kakaoLogin("CUSTOMER")}
             />
-            <Image src={naver} alt="naver" width={62} height={62} className="cursor-pointer" />
+            <Image
+              src={naver}
+              alt="naver"
+              width={62}
+              height={62}
+              className="cursor-pointer"
+              onClick={() => naverLogin("CUSTOMER")}
+            />
           </div>
 
           {deviceType === "tablet" && (

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -36,6 +36,7 @@ interface IAuthContextType {
   signUp: (signUpData: ISignUpFormValues) => Promise<TSignInResponse>;
   googleLogin: (userType: "CUSTOMER" | "MOVER") => Promise<void>;
   kakaoLogin: (userType: "CUSTOMER" | "MOVER") => Promise<void>;
+  naverLogin: (userType: "CUSTOMER" | "MOVER") => Promise<void>;
   logout: () => void;
   getUser: () => Promise<void>;
 }
@@ -58,6 +59,7 @@ const AuthContext = createContext<IAuthContextType>({
   }),
   googleLogin: async () => {},
   kakaoLogin: async () => {},
+  naverLogin: async () => {},
   logout: () => {},
   getUser: async () => {},
 });
@@ -223,6 +225,20 @@ export default function AuthProvider({ children }: IAuthProviderProps) {
   };
 
   /**
+   * 네이버 로그인 함수
+   */
+  const naverLogin = async (userType: "CUSTOMER" | "MOVER") => {
+    try {
+      setIsLoading(true);
+      await authApi.naverLogin(userType);
+    } catch (error: unknown) {
+      console.error("네이버 로그인 실패:", error);
+      setIsLoading(false);
+      throw error;
+    }
+  };
+
+  /**
    * 새로고침 시 인증 상태 확인
    */
   useEffect(() => {
@@ -250,6 +266,7 @@ export default function AuthProvider({ children }: IAuthProviderProps) {
     signUp,
     googleLogin,
     kakaoLogin,
+    naverLogin,
     logout,
     getUser,
   };

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -23,6 +23,7 @@ export type TSignInResponse = {
     userType: "CUSTOMER" | "MOVER";
   };
   success: boolean;
+  status?: number;
   message: string;
   accessToken: string;
 };
@@ -34,6 +35,7 @@ interface IAuthContextType {
   login: (email: string, password: string, userType: "CUSTOMER" | "MOVER") => Promise<TSignInResponse>;
   signUp: (signUpData: ISignUpFormValues) => Promise<TSignInResponse>;
   googleLogin: (userType: "CUSTOMER" | "MOVER") => Promise<void>;
+  kakaoLogin: (userType: "CUSTOMER" | "MOVER") => Promise<void>;
   logout: () => void;
   getUser: () => Promise<void>;
 }
@@ -55,6 +57,7 @@ const AuthContext = createContext<IAuthContextType>({
     accessToken: "",
   }),
   googleLogin: async () => {},
+  kakaoLogin: async () => {},
   logout: () => {},
   getUser: async () => {},
 });
@@ -202,6 +205,23 @@ export default function AuthProvider({ children }: IAuthProviderProps) {
       throw error;
     }
   };
+
+  /**
+   * 카카오 로그인 함수
+   */
+  const kakaoLogin = async (userType: "CUSTOMER" | "MOVER") => {
+    try {
+      setIsLoading(true);
+      // 페이지 리디렉션 방식으로 변경 (Promise<void> 반환)
+      await authApi.kakaoLogin(userType);
+      // 리디렉션이 발생하므로 이후 코드는 실행되지 않음
+    } catch (error: unknown) {
+      console.error("카카오 로그인 실패:", error);
+      setIsLoading(false);
+      throw error;
+    }
+  };
+
   /**
    * 새로고침 시 인증 상태 확인
    */
@@ -229,6 +249,7 @@ export default function AuthProvider({ children }: IAuthProviderProps) {
     login,
     signUp,
     googleLogin,
+    kakaoLogin,
     logout,
     getUser,
   };


### PR DESCRIPTION
## ✨ 작업 개요
- 구글/카카오/네이버 소셜 로그인 구현

## ✅ 주요 작업 내용
- 로그인 콜백 전용 페이지 구현
- 구글 리디렉션 로그인 구현
- 카카오 리디렉션 로그인 구현
- 네이버 리디렉션 로그인 구현

## 🔄 관련 이슈
Closes #58 

## 📸 스크린샷 (선택)
### 콜백 전용 페이지
<img width="1684" height="918" alt="로그인 콜백 전용 페이지" src="https://github.com/user-attachments/assets/75cfa235-e57c-4cd7-92aa-d71ff40d577d" />

### 로그인 성공 후 삽인된 디비 데이터
<img width="1625" height="116" alt="소셜 로그인 성공" src="https://github.com/user-attachments/assets/e0f5ac85-95f4-47dd-ac69-5e629d645bfb" />


## 🧪 테스트 방법 (선택)
- [ ] 로그인/회원가입 페이지에서 각각의 소셜 로그인 진행 후 로그인한 유저 타입이 제대로 저장 되는지 디비 확인

## 📝 비고
- 현재 네이버는 요청 url을 한 개만 설정 가능해서 배포 주소만 설정해둔 상태입니다.