### PR TITLE
[#172] [#197] [#199] Feat/notification 실시간 알림 기능 문제 해결.

### DIFF
--- a/src/components/common/dropdown/UserActionDropdown.tsx
+++ b/src/components/common/dropdown/UserActionDropdown.tsx
@@ -39,14 +39,14 @@ const DropdownHeader = ({
   onClose?: () => void;
   showCloseButton?: boolean;
 }) => (
-  <div className="inline-flex w-full items-center justify-between bg-white py-3.5 pr-3 pl-4">
+  <div className="inline-flex w-full items-center justify-between bg-white py-3.5 pr-3 pl-4 cursor-default">
     <div className="flex items-center justify-start">
       <div className="leading-2lg text-black-400 lg:text-2lg text-left text-base font-bold">{title}</div>
     </div>
     {showCloseButton && onClose && (
       <button
         onClick={onClose}
-        className="flex h-6 w-6 items-center justify-center text-gray-400 transition-colors hover:text-gray-600"
+        className="flex h-6 w-6 items-center justify-center text-gray-400 transition-colors hover:text-gray-600 cursor-pointer"
         aria-label="닫기"
       >
         <IoClose size={20} />

--- a/src/components/common/gnb/GnbActions.tsx
+++ b/src/components/common/gnb/GnbActions.tsx
@@ -24,7 +24,7 @@ const USER_ACTION_LIST = [
   },
   {
     label: "이사 리뷰",
-    href: "/user/order",
+    href: "/review/written",
   },
 ];
 
@@ -70,7 +70,13 @@ export const GnbActions = ({ userRole, userName, deviceType, toggleSideMenu, isS
   const fetchNotifications = useNotificationStore((state) => state.fetchNotifications);
 
   const handleNotificationClick = () => {
-    setIsNotificationOpen((prev) => !prev);
+    setIsNotificationOpen((prev) => {
+      const willOpen = !prev;
+      if (willOpen) {
+        fetchNotifications(4, 0); // 모달이 열릴 때만 전체 알림(첫 페이지) 받아오기
+      }
+      return willOpen;
+    });
   };
 
   // 프로필 버튼 클릭 시 프로필 모달창 열기
@@ -123,10 +129,11 @@ export const GnbActions = ({ userRole, userName, deviceType, toggleSideMenu, isS
     };
   }, [isProfileOpen]);
 
-  // useEffect(() => {
-  //   // 최초 1회만 전체 알림의 hasUnread, total 등 받아오기
-  //   fetchNotifications(1, 0);
-  // }, [fetchNotifications]);
+  useEffect(() => {
+    // 헤더가 보일 때(마운트 시) 최신 알림 1개만 받아와서 hasUnread만 갱신
+    fetchNotifications(1, 0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div className="flex items-center gap-4">
@@ -162,7 +169,7 @@ export const GnbActions = ({ userRole, userName, deviceType, toggleSideMenu, isS
                 isOpen={isNotificationOpen}
                 triggerRef={notificationButtonRef}
               >
-                {/* <NotificationList /> */}
+                <NotificationList onClose={() => setIsNotificationOpen(false)} />
               </UserActionDropdown>
             </div>
           </div>
@@ -183,7 +190,7 @@ export const GnbActions = ({ userRole, userName, deviceType, toggleSideMenu, isS
             {isProfileOpen && (
               <div
                 ref={profileModalRef}
-                className="absolute top-full right-0 z-50 mt-2 w-[248px] rounded-2xl border-2 border-[#F2F2F2] bg-white px-2 py-2.5 font-bold shadow-lg lg:w-[248px]"
+                className="absolute top-full right-0 z-50 mt-2 w-[180px] rounded-2xl border-2 border-[#F2F2F2] bg-white px-2 py-2.5 font-bold shadow-lg lg:w-[248px]"
               >
                 <nav className="flex flex-col items-start justify-start border-b border-[#F2F2F2]">
                   <span className="w-full px-2 py-2 text-left text-lg">

--- a/src/components/notification/NotificationList.tsx
+++ b/src/components/notification/NotificationList.tsx
@@ -8,10 +8,9 @@ import parse from "html-react-parser";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import "dayjs/locale/ko";
-import { readNotification } from "@/lib/api/notification.api";
+import { markAsRead } from "@/lib/api/notification.api";
 import { useRouter } from "next/navigation";
 import { INotification } from "@/types/notification.types";
-
 
 dayjs.extend(relativeTime);
 dayjs.locale("ko");
@@ -44,11 +43,12 @@ export default function NotificationList() {
   // 알림 클릭 핸들러
   const handleClick = async (notification: INotification) => {
     try {
-      await readNotification(notification.id);
+      await markAsRead(notification.id);
+      onClose?.();
+      router.push(notification.path);
     } catch (e) {
-      // 에러 무시하고 이동
+      console.error(e);
     }
-    router.push(notification.actionUrl);
   };
 
   if (notifications.length === 0) {
@@ -61,13 +61,13 @@ export default function NotificationList() {
 
   return (
     <div className="text-black-400 max-h-[215px] w-full overflow-y-auto">
-      {notifications.map((notification, idx) => (
-        notification.actionUrl ? (
+      {notifications.map((notification, idx) =>
+        notification.path ? (
           <div
             key={`${notification.id}-${idx}`}
             className={`flex cursor-pointer flex-col items-start p-4 hover:bg-gray-50 ${
-              idx !== notifications.length - 1 ? "border-b border-gray-200" : ""
-            }`}
+              notification.isRead ? "bg-gray-100" : ""
+            } ${idx !== notifications.length - 1 ? "border-b border-gray-200" : ""}`}
             onClick={() => handleClick(notification)}
           >
             <div className="text-sm break-words">{parse(DOMPurify.sanitize(notification.title))}</div>
@@ -83,8 +83,8 @@ export default function NotificationList() {
             <div className="text-sm break-words">{parse(DOMPurify.sanitize(notification.title))}</div>
             <div className="mt-1 text-xs text-gray-400">{dayjs(notification.createdAt).fromNow()}</div>
           </div>
-        )
-      ))}
+        ),
+      )}
       {hasMore && <div ref={ref} style={{ height: 40 }} />}
       {!hasMore && <div className="py-2 text-center text-xs text-gray-400">모든 알림을 불러왔습니다.</div>}
     </div>

--- a/src/components/notification/NotificationList.tsx
+++ b/src/components/notification/NotificationList.tsx
@@ -8,22 +8,20 @@ import parse from "html-react-parser";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import "dayjs/locale/ko";
-import { markAsRead } from "@/lib/api/notification.api";
 import { useRouter } from "next/navigation";
 import { INotification } from "@/types/notification.types";
 
 dayjs.extend(relativeTime);
 dayjs.locale("ko");
 
-export default function NotificationList() {
-  const { notifications, hasMore, fetchNotifications } = useNotificationStore();
+export default function NotificationList({ onClose }: { onClose?: () => void }) {
+  const notifications = useNotificationStore((state) => state.notifications);
+  const hasMore = useNotificationStore((state) => state.hasMore);
+  const fetchNotifications = useNotificationStore((state) => state.fetchNotifications);
+  const markAsRead = useNotificationStore((state) => state.markAsRead);
   const limit = 4;
   const loadingRef = useRef(false);
   const router = useRouter();
-
-  useEffect(() => {
-    fetchNotifications(limit, 0);
-  }, []);
 
   const { ref, inView } = useInView({ threshold: 0.2 });
 
@@ -40,7 +38,7 @@ export default function NotificationList() {
     }
   }, [inView, hasMore, loadMore]);
 
-  // 알림 클릭 핸들러
+  // 알림 클릭 핸들러 -> 읽음처리 후 이동.
   const handleClick = async (notification: INotification) => {
     try {
       await markAsRead(notification.id);

--- a/src/providers/NotificationSSEProvider.tsx
+++ b/src/providers/NotificationSSEProvider.tsx
@@ -2,14 +2,17 @@
 
 import { useEffect } from "react";
 import { useNotificationStore } from "@/stores/notificationStore";
+import { getTokenFromCookie } from "@/utils/auth";
 
 export default function NotificationSSEProvider({ children }: { children: React.ReactNode }) {
   const connectSSE = useNotificationStore((state) => state.connectSSE);
   const disconnectSSE = useNotificationStore((state) => state.disconnectSSE);
 
   useEffect(() => {
-    const token = localStorage.getItem("accessToken");
-    if (token) connectSSE(token);
+    (async () => {
+      const token = await getTokenFromCookie();
+      if (token) connectSSE(token);
+    })();
     return () => {
       disconnectSSE();
     };

--- a/src/types/notification.types.ts
+++ b/src/types/notification.types.ts
@@ -1,7 +1,12 @@
 export interface INotification {
   id: string;
+  actionId: string;
+  userId: string;
+  type: string;
   title: string;
-  actionUrl: string;
+  content: string;
+  path: string;
+  isRead: boolean;
   createdAt: string;
-  unread: boolean;
+  updatedAt: string;
 }


### PR DESCRIPTION
## ✨ 작업 개요
- 여러 원인으로 인한 실시간 알림 기능 문제 해결.

## ✅ 주요 작업 내용
- 스키마 대공사로 인한 타입 변경.
- 알림 읽음 처리 후 변하지 않는 UI 문제 해결.
- 새로운 알림이 생성 되었을때 실시간으로 바뀌지 않는 문제 해결.

## ✅ 작업 항목
- [x] 스키마 및 BE API에 맞게 타입 및 변수명 변경.
- [x] 읽음 처리 후 페이지 이동과 더불어 새로운 알림이 있는지 확인을 위해 데이터 리패칭.
- [x] SSE 실시간 알림 부분 코드 변경. eventSource.onmessage -> eventSource.addEventListener

## 🔄 관련 이슈
Closes #172 - 스키마 대공사 리팩토링.
Closes #197 - 알림 읽음 처리 후 UI 문제 해결.
Closes #199 - SSE 실시간 알림 기능 문제 해결.


## 📸 스크린샷 (선택)

> https://github.com/user-attachments/assets/059fad03-168a-42cf-9db7-5bb1656f32b5

## 🧪 테스트 방법 (선택)
- [ ] 테스트용 알림 생성을 위해 2개의 창에 각각 일반회원과 기사님으로 로그인. (하나는 시크릿창 사용)
- [ ] 일반 회원은 임시 페이지인(/notification) 알림 페이지에서 알림 생성 버튼 클릭.
- [ ] 테스트용 알림은 모든 기사님에게 날아가기 때문에 기사님 알림이 실시간으로 추가되는 것을 확인.

## 📝 비고
- 테스트용 알림 생성 API 및 notification 페이지는 삭제 예정입니다.
- 현재는 테스트도 겸할 생각으로 새로운 견적요청이 생성되면 모든 기사님에게 알림이 갑니다. 
- 추후 리팩토링 과정에서 서비스 가능 지역에 해당하는 기사님에게만 가도록 변경 예정입니다. - 챌린지 사항.

