### PR TITLE
Feat:마이페이지 리뷰리스트 api연동  및 리뷰 리스트 수정

### DIFF
--- a/src/components/searchMover/[id]/ReviewAvg.tsx
+++ b/src/components/searchMover/[id]/ReviewAvg.tsx
@@ -1,25 +1,80 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import inactiveStar from "@/assets/icon/star/icon-star-inactive-lg.png";
 import activeStar from "@/assets/icon/star/icon-star-active-lg.png";
 import Image from "next/image";
-import { MoverWithReviewsProps } from "@/types/moverDetail";
+import { MoverWithReceivedReviewsProps } from "@/types/moverDetail";
+import reviewApi from "@/lib/api/review.api";
 
-const ReviewAvg = ({ mover, reviews }: MoverWithReviewsProps) => {
-  const total = reviews.length;
-  const avg = total > 0 ? reviews.reduce((sum, r) => sum + r.rating, 0) / total : 0;
+interface ReviewStats {
+  averageRating: number;
+  totalReviewCount: number;
+  ratingDistribution: { [key: number]: number };
+}
 
-  // 점수별 개수 계산
-  const reviewCounts = [5, 4, 3, 2, 1].reduce(
+const ReviewAvg = ({ mover, reviews }: MoverWithReceivedReviewsProps) => {
+  const [stats, setStats] = useState<ReviewStats | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!mover.id) return;
+
+    const fetchStats = async () => {
+      try {
+        setLoading(true);
+        const reviewStats = await reviewApi.fetchMoverReviewStats(String(mover.id));
+        setStats(reviewStats);
+      } catch (error) {
+        console.error("리뷰 통계 조회 실패:", error);
+        // API 실패 시 현재 리뷰 데이터로 계산
+        const total = reviews.length;
+        const avg = total > 0 ? reviews.reduce((sum, r) => sum + r.rating, 0) / total : 0;
+        const ratingDistribution = [5, 4, 3, 2, 1].reduce(
+          (acc, score) => {
+            acc[score] = reviews.filter((r) => r.rating === score).length;
+            return acc;
+          },
+          { 5: 0, 4: 0, 3: 0, 2: 0, 1: 0 } as { [key: number]: number },
+        );
+        setStats({
+          averageRating: avg,
+          totalReviewCount: total,
+          ratingDistribution,
+        });
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchStats();
+  }, [mover.id, reviews]);
+
+  // API 데이터가 없으면 현재 리뷰 데이터로 계산
+  const total = stats?.totalReviewCount || reviews.length;
+  const avg = stats?.averageRating || (reviews.length > 0 ? reviews.reduce((sum, r) => sum + r.rating, 0) / reviews.length : 0);
+  const ratingDistribution = stats?.ratingDistribution || [5, 4, 3, 2, 1].reduce(
     (acc, score) => {
       acc[score] = reviews.filter((r) => r.rating === score).length;
       return acc;
     },
-    { 5: 0, 4: 0, 3: 0, 2: 0, 1: 0 } as Record<number, number>,
+    { 5: 0, 4: 0, 3: 0, 2: 0, 1: 0 } as { [key: number]: number },
   );
 
-  const maxCount = Math.max(...Object.values(reviewCounts));
+  const maxCount = Math.max(...Object.values(ratingDistribution));
+
+  if (loading) {
+    return (
+      <div>
+        <div className="flex flex-col gap-4">
+          <p className="text-xl font-semibold">리뷰</p>
+          <div className="flex items-center justify-center py-8">
+            <div className="border-primary-400 h-6 w-6 animate-spin rounded-full border-4 border-t-transparent"></div>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div>
@@ -44,7 +99,7 @@ const ReviewAvg = ({ mover, reviews }: MoverWithReviewsProps) => {
           </div>
           <div className="flex w-[284px] flex-col gap-3">
             {[5, 4, 3, 2, 1].map((score) => {
-              const count = reviewCounts[score as keyof typeof reviewCounts];
+              const count = ratingDistribution[score] || 0;
               const percent = total > 0 ? (count / total) * 100 : 0;
               const isMax = count === maxCount && count > 0;
               return (

--- a/src/pageComponents/moverMyPage/MoverMyPage.tsx
+++ b/src/pageComponents/moverMyPage/MoverMyPage.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import userApi from "@/lib/api/user.api";
+import reviewApi from "@/lib/api/review.api";
 import Image from "next/image";
 import defaultHeader from "@/assets/img/etc/detailHeader.png";
 import editIcon from "@/assets/icon/edit/icon-edit.png";
@@ -14,8 +15,7 @@ import { useRouter } from "next/navigation";
 import { useLocale } from "next-intl";
 import ReviewAvg from "@/components/searchMover/[id]/ReviewAvg";
 import ReviewList from "@/components/searchMover/[id]/ReviewList";
-import { getMockReviewsForMover } from "@/lib/utils/mockReviewData";
-import { IMoverInfo, IReview } from "@/types/findMover";
+import { IMoverInfo, IReceivedReview } from "@/types/findMover";
 
 interface IMoverInfoExtended extends IMoverInfo {
   moverImage?: string;
@@ -32,7 +32,8 @@ const MoverMyPage = () => {
   const router = useRouter();
   const locale = useLocale();
   const [profile, setProfile] = useState<IMoverInfoExtended | null>(null);
-  const [reviews, setReviews] = useState<IReview[]>([]);
+  const [reviews, setReviews] = useState<IReceivedReview[]>([]);
+  const [reviewStats, setReviewStats] = useState<{ averageRating: number; totalReviewCount: number } | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -57,12 +58,38 @@ const MoverMyPage = () => {
     fetchProfile();
   }, []);
 
+  // 리뷰 데이터를 받아서 평균 평점 계산에 사용
+  const handleReviewsFetched = useCallback((fetchedReviews: IReceivedReview[]) => {
+    setReviews(fetchedReviews);
+  }, []);
+
+  // 리뷰 통계 데이터 가져오기
   useEffect(() => {
-    if (profile) {
-      const mockReviews = getMockReviewsForMover(profile.id);
-      setReviews(mockReviews);
-    }
-  }, [profile]);
+    if (!profile?.id) return;
+
+    const fetchReviewStats = async () => {
+      try {
+        const stats = await reviewApi.fetchMoverReviewStats(String(profile.id));
+        setReviewStats({
+          averageRating: stats.averageRating,
+          totalReviewCount: stats.totalReviewCount
+        });
+      } catch (error) {
+        console.error("리뷰 통계 조회 실패:", error);
+        // API 실패 시 현재 리뷰 데이터로 계산
+        if (reviews.length > 0) {
+          setReviewStats({
+            averageRating: reviews.reduce((sum, r) => sum + r.rating, 0) / reviews.length,
+            totalReviewCount: reviews.length
+          });
+        }
+      }
+    };
+
+    fetchReviewStats();
+  }, [profile?.id, reviews.length]);
+
+
 
   const getServiceName = (serviceType: string): string => {
     const serviceNameMap: { [key: string]: string } = {
@@ -143,13 +170,13 @@ const MoverMyPage = () => {
                       {profile.isVeteran && (
                         <Image src={chatIcon} alt="veteran-icon" className="w-6 h-6" />
                       )}
-                      <div className="justify-center text-zinc-800 text-2xl font-semibold font-['Pretendard'] leading-loose">{profile.nickname}</div>
+                      <div className="justify-center text-zinc-800 text-2xl font-semibold leading-loose">{profile.nickname}</div>
                     </div>
                     <div className="inline-flex justify-start items-center gap-1">
                       <Favorite
                         isFavorited={true}
                         favoriteCount={profile.totalFavoriteCount || 0}
-                        moverId={profile.id}
+                        moverId={String(profile.id)}
                         favoritedColor="text-black"
                         unfavoritedColor="text-black"
                         textColor="text-zinc-500"
@@ -182,7 +209,7 @@ const MoverMyPage = () => {
                   className="self-stretch h-16 p-4 w-full rounded-2xl outline outline-1 outline-offset-[-1px] outline-stone-300 inline-flex justify-center items-center hover:bg-gray-50 transition-colors cursor-pointer"
                 >
                   <div className="flex justify-start items-center gap-1.5">
-                    <div className="text-center justify-center text-neutral-400 text-lg font-semibold font-['Pretendard'] leading-relaxed">기본 정보 수정</div>
+                    <div className="text-center justify-center text-neutral-400 text-lg font-semibold leading-relaxed">기본 정보 수정</div>
                     <div className="w-6 h-6 relative overflow-hidden">
                       <Image src={editGrayIcon} alt="edit-icon" className="w-6 h-6" />
                     </div>
@@ -196,7 +223,7 @@ const MoverMyPage = () => {
                   className="flex-1 h-16 p-4 rounded-2xl outline outline-1 outline-offset-[-1px] outline-stone-300 inline-flex justify-center items-center hover:bg-gray-50 transition-colors cursor-pointer"
                 >
                   <div className="flex justify-start items-center gap-1.5">
-                    <div className="text-center justify-center text-neutral-400 text-lg font-semibold font-['Pretendard'] leading-relaxed">기본 정보 수정</div>
+                    <div className="text-center justify-center text-neutral-400 text-lg font-semibold leading-relaxed">기본 정보 수정</div>
                     <div className="w-6 h-6 relative overflow-hidden">
                       <Image src={editGrayIcon} alt="edit-icon" className="w-6 h-6" />
                     </div>
@@ -213,29 +240,29 @@ const MoverMyPage = () => {
               
               <div className="w-full h-0 outline outline-1 outline-offset-[-0.50px] outline-zinc-100" />
               <div className="self-stretch flex flex-col justify-start items-start gap-4">
-                <div className="self-stretch justify-start text-neutral-800 text-xl font-semibold font-['Pretendard'] leading-loose">활동 현황</div>
+                <div className="self-stretch justify-start text-neutral-800 text-xl font-semibold leading-loose">활동 현황</div>
                 <div className="self-stretch h-28 px-40 bg-neutral-50 rounded-2xl outline outline-1 outline-offset-[-1px] outline-zinc-100 inline-flex justify-between items-center">
                   <div className="w-14 inline-flex flex-col justify-start items-center gap-1">
-                    <div className="self-stretch text-center justify-start text-zinc-800 text-base font-normal font-['Pretendard'] leading-relaxed">진행</div>
-                    <div className="self-stretch text-center justify-center text-red-500 text-xl font-bold font-['Pretendard'] leading-loose">{profile.workedCount || 0}건</div>
+                    <div className="self-stretch text-center justify-start text-zinc-800 text-base font-normal leading-relaxed">진행</div>
+                    <div className="self-stretch text-center justify-center text-red-500 text-xl font-bold leading-loose">{String(profile.workedCount || 0)}건</div>
                   </div>
                   <div className="w-24 inline-flex flex-col justify-start items-center gap-1">
-                    <div className="text-center justify-start text-zinc-800 text-base font-normal font-['Pretendard'] leading-relaxed">리뷰</div>
+                    <div className="text-center justify-start text-zinc-800 text-base font-normal leading-relaxed">리뷰</div>
                     <div className="inline-flex justify-start items-center gap-1.5">
-                      <div className="justify-center text-red-500 text-xl font-bold font-['Pretendard'] leading-loose">
-                        {reviews.length > 0 ? (reviews.reduce((sum, r) => sum + r.rating, 0) / reviews.length).toFixed(1) : "0.0"}
+                      <div className="justify-center text-red-500 text-xl font-bold leading-loose">
+                        {reviewStats ? reviewStats.averageRating.toFixed(1) : "0.0"}
                       </div>
                     </div>
                   </div>
                   <div className="w-16 inline-flex flex-col justify-start items-center gap-1">
-                    <div className="self-stretch text-center justify-start text-zinc-800 text-base font-normal font-['Pretendard'] leading-relaxed whitespace-nowrap">총 경력</div>
-                    <div className="self-stretch text-center justify-center text-red-500 text-xl font-bold font-['Pretendard'] leading-loose">{profile.career}년</div>
+                    <div className="self-stretch text-center justify-start text-zinc-800 text-base font-normal leading-relaxed whitespace-nowrap">총 경력</div>
+                    <div className="self-stretch text-center justify-center text-red-500 text-xl font-bold leading-loose">{String(profile.career)}년</div>
                   </div>
                 </div>
               </div>
             </div>
             <div className="flex flex-col justify-start items-start gap-4">
-              <div className="justify-start text-neutral-800 text-xl font-semibold font-['Pretendard'] leading-loose">제공 서비스</div>
+              <div className="justify-start text-neutral-800 text-xl font-semibold leading-loose">제공 서비스</div>
               <div className="inline-flex items-start justify-start gap-1.5 lg:gap-3">
                 {profile.serviceTypes && profile.serviceTypes.length > 0 ? (
                   profile.serviceTypes.map((serviceType: string, idx: number) => (
@@ -251,7 +278,7 @@ const MoverMyPage = () => {
               </div>
             </div>
             <div className="flex flex-col justify-start items-start gap-4">
-              <div className="justify-start text-neutral-800 text-xl font-semibold font-['Pretendard'] leading-loose">서비스 가능 지역</div>
+              <div className="justify-start text-neutral-800 text-xl font-semibold leading-loose">서비스 가능 지역</div>
               <div className="flex flex-wrap items-start gap-1.5 lg:gap-3 max-w-full">
                 {profile.currentAreas && profile.currentAreas.map((area: string, idx: number) => (
                   <CircleTextLabel
@@ -271,7 +298,20 @@ const MoverMyPage = () => {
               </div>
               
               <div className="w-full">
-                <ReviewList moverId={1} />
+                {profile?.id ? (
+                  <ReviewList 
+                    moverId={String(profile.id)} 
+                    onReviewsFetched={handleReviewsFetched} 
+                  />
+                ) : (
+                  <div className="w-full">
+                    <p className="mb-[51px] text-xl font-semibold">리뷰</p>
+                    <div className="flex flex-col items-center">
+                      <p className="text-lg font-semibold">프로필 정보를 불러올 수 없습니다.</p>
+                      <p className="text-md text-[#999999]">로그인 상태를 확인해주세요</p>
+                    </div>
+                  </div>
+                )}
               </div>
             </div>
           </div>
@@ -289,7 +329,7 @@ const MoverMyPage = () => {
               className="self-stretch h-16 p-4 lg:w-[283px] rounded-2xl outline outline-1 outline-offset-[-1px] outline-stone-300 inline-flex justify-center items-center hover:bg-gray-50 transition-colors cursor-pointer"
             >
               <div className="flex justify-start items-center gap-1.5">
-                <div className="text-center justify-center text-neutral-400 text-lg font-semibold font-['Pretendard'] leading-relaxed">기본 정보 수정</div>
+                <div className="text-center justify-center text-neutral-400 text-lg font-semibold leading-relaxed">기본 정보 수정</div>
                 <div className="w-6 h-6 relative overflow-hidden">
                   <Image src={editGrayIcon} alt="edit-icon" className="w-6 h-6" />
                 </div>

--- a/src/types/findMover.ts
+++ b/src/types/findMover.ts
@@ -51,8 +51,58 @@ export interface IReview {
   };
 }
 
+// 실제 API 응답 구조에 맞는 리뷰 타입
+export interface IReceivedReview {
+  id: string;
+  estimateRequestId: string | null;
+  customerId: string;
+  moverId: string;
+  profileImage: string | null;
+  nickname: string;
+  moveType: "SMALL" | "HOME" | "OFFICE" | null;
+  isDesigned: boolean;
+  moverIntroduction: string | null;
+  fromAddress: {
+    city: string;
+    district: string;
+    detail: string;
+    region: string;
+  } | null;
+  toAddress: {
+    city: string;
+    district: string;
+    detail: string;
+    region: string;
+  } | null;
+  moveDate: string | null;
+  rating: number;
+  content: string;
+  createdAt: string;
+  estimate: {
+    id: string;
+    price: number;
+    comment: string | null;
+    status: string;
+    isDesignated: boolean;
+    validUntil: string;
+    workingHours: number;
+    includesPackaging: boolean;
+    insuranceAmount: number;
+    createdAt: string;
+    updatedAt: string;
+  } | null;
+}
+
 export interface IReviewListResponse {
   items: IReview[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+// 실제 API 응답 구조에 맞는 리뷰 리스트 응답 타입
+export interface IReceivedReviewListResponse {
+  items: IReceivedReview[];
   total: number;
   page: number;
   pageSize: number;

--- a/src/types/moverDetail.ts
+++ b/src/types/moverDetail.ts
@@ -1,18 +1,26 @@
-import { IMoverInfo, IReview } from "./findMover";
+import { IMoverInfo, IReview, IReceivedReview } from "./findMover";
 
 export interface MoverProps {
   mover: IMoverInfo;
 }
 
+// 일반 리뷰를 위한 타입들
 export interface ReviewsProps {
   reviews: IReview[];
 }
 
 export interface MoverWithReviewsProps extends MoverProps, ReviewsProps {}
 
+// 기사님이 받은 리뷰를 위한 타입들
+export interface ReceivedReviewsProps {
+  reviews: IReceivedReview[];
+}
+
+export interface MoverWithReceivedReviewsProps extends MoverProps, ReceivedReviewsProps {}
+
 export interface ReviewListProps {
-  moverId: number;
-  onReviewsFetched?: (reviews: IReview[]) => void;
+  moverId: string | undefined;
+  onReviewsFetched?: (reviews: IReceivedReview[]) => void;
 }
 
 export interface TopBarProps {


### PR DESCRIPTION
## ✨ 작업 개요
- 기사님 마이페이지의 리뷰 섹션을 목데이터에서 실제 API 연동으로 변경
- 일반 유저들의 이름을 마스킹 처리하여 개인정보 보호 기능 추가
- 리뷰 평점과 분포도를 모든 리뷰 데이터를 기반으로 계산하도록 개선

## ✅ 주요 작업 내용
ReviewList  
- 목데이터 제거하고 실제 API 연동
- 이름 마스킹 함수(maskName) 추가: 첫 글자만 보이고 나머지는 *로 표시

MoverMyPage 
- reviewStats 상태 추가로 전체 리뷰 통계 관리
- handleReviewsFetched 콜백 함수 메모이제이션
- 조건부 렌더링으로 profile?.id 확인 후 컴포넌트 렌더링


## 🔄 관련 이슈
Closes #이슈번호

## 📸 스크린샷 (선택)
<img width="839" height="745" alt="image" src="https://github.com/user-attachments/assets/50cd7a57-cc76-494b-b3c5-c3027f7c02fd" />
<img width="839" height="777" alt="image" src="https://github.com/user-attachments/assets/72272bcf-66d9-4f72-9b8f-6a78f67e39f0" />


## 🧪 테스트 방법 (선택)
- [ ] 기사님 마이페이지 진입 시 리뷰 목록 정상 표시
- [ ] 리뷰 작성자 이름이 마스킹 처리되어 표시 (예: "김철수" → "김")
- [ ] 리뷰 평점과 분포도가 전체 리뷰 기준으로 정확히 계산되어 표시
- [ ] 페이지네이션 동작 확인 (5개씩 표시)

## 📝 비고
- (버그, 추후 개선사항 등)