### PR TITLE
Feat:기사님 페이지 다국어 기능 완성 및 UI 개선

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -246,7 +246,34 @@
 
     "currentArea": "My Area",
     "currentAreaInfo": "You can edit your area anytime!",
-    "currentAreas": "Service Areas"
+    "currentAreas": "Service Areas",
+    "edit": {
+      "title": "Edit Profile",
+      "profileImage": "Profile Image",
+      "nickname": "Nickname",
+      "nicknamePlaceholder": "Enter your nickname",
+      "career": "Career",
+      "careerPlaceholder": "ex) 8",
+      "shortIntro": "Introduction",
+      "shortIntroPlaceholder": "Enter a brief introduction (minimum 8 characters)",
+      "detailIntro": "Description",
+      "detailIntroPlaceholder": "Enter a detailed description (minimum 10 characters)",
+      "providedServices": "Provided Services",
+      "serviceAreas": "Service Areas",
+      "required": "*",
+      "requiredField": "Required",
+      "minLength8": "Please enter at least 8 characters",
+      "minLength10": "Please enter at least 10 characters",
+      "minCareer": "Career must be at least 0 years",
+      "save": "Save Changes",
+      "cancel": "Cancel",
+      "successTitle": "Profile Update Complete",
+      "successMessage": "Profile has been updated successfully.",
+      "errorTitle": "Profile Update Failed",
+      "errorMessage": "Update failed.",
+      "generalError": "An error occurred.",
+      "confirm": "Confirm"
+    }
   },
   "search": {
     "title": "Search Moving Companies",
@@ -328,6 +355,19 @@
     "yearsMobile": "y",
     "casesMobile": "",
     "confirmedMobile": "Done",
+    "myPage": {
+      "loading": "Loading...",
+      "retry": "Retry",
+      "profileNotFound": "Profile information not found.",
+      "editProfile": "Edit My Profile",
+      "editBasicInfo": "Edit Basic Info",
+      "activityStatus": "Activity Status",
+      "inProgress": "In Progress",
+      "reviews": "Reviews",
+      "totalExperience": "Career",
+      "providedServices": "Provided Services",
+      "serviceAreas": "Service Areas"
+    },
     "serviceTypes": {
       "small": "Small Move",
       "home": "Home Move",

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -242,7 +242,34 @@
 
     "currentArea": "내가 사는 지역",
     "currentAreaInfo": "내가 사는 지역은 언제든 수정 가능해요!",
-    "currentAreas": "서비스 가능 지역"
+    "currentAreas": "서비스 가능 지역",
+    "edit": {
+      "title": "프로필 수정",
+      "profileImage": "프로필 이미지",
+      "nickname": "별명",
+      "nicknamePlaceholder": "별명을 입력하세요",
+      "career": "경력",
+      "careerPlaceholder": "ex) 8",
+      "shortIntro": "한 줄 소개",
+      "shortIntroPlaceholder": "한 줄 소개를 입력하세요 (최소 8자)",
+      "detailIntro": "상세 설명",
+      "detailIntroPlaceholder": "상세 설명을 입력하세요 (최소 10자)",
+      "providedServices": "제공 서비스",
+      "serviceAreas": "서비스 가능 지역",
+      "required": "*",
+      "requiredField": "필수 입력",
+      "minLength8": "8자 이상 입력해주세요",
+      "minLength10": "10자 이상 입력해주세요",
+      "minCareer": "경력은 0년 이상이어야 합니다",
+      "save": "수정하기",
+      "cancel": "취소",
+      "successTitle": "프로필 수정 완료",
+      "successMessage": "프로필 수정이 완료되었습니다.",
+      "errorTitle": "프로필 수정 실패",
+      "errorMessage": "수정에 실패했습니다.",
+      "generalError": "오류가 발생했습니다.",
+      "confirm": "확인"
+    }
   },
   "search": {
     "title": "이사업체 검색",
@@ -324,6 +351,19 @@
     "yearsMobile": "년",
     "casesMobile": "건",
     "confirmedMobile": "확정",
+    "myPage": {
+      "loading": "로딩 중...",
+      "retry": "다시 시도",
+      "profileNotFound": "프로필 정보를 찾을 수 없습니다.",
+      "editProfile": "내 프로필 수정",
+      "editBasicInfo": "기본 정보 수정",
+      "activityStatus": "활동 현황",
+      "inProgress": "진행",
+      "reviews": "리뷰",
+      "totalExperience": "총 경력",
+      "providedServices": "제공 서비스",
+      "serviceAreas": "서비스 가능 지역"
+    },
     "serviceTypes": {
       "small": "소형이사",
       "home": "가정이사",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -247,7 +247,34 @@
 
     "currentArea": "所在地区",
     "currentAreaInfo": "可以随时修改所在地区！",
-    "currentAreas": "服务范围"
+    "currentAreas": "服务范围",
+    "edit": {
+      "title": "编辑个人资料",
+      "profileImage": "个人资料图片",
+      "nickname": "昵称",
+      "nicknamePlaceholder": "请输入昵称",
+      "career": "工作经验",
+      "careerPlaceholder": "例如：8",
+      "shortIntro": "一句话介绍",
+      "shortIntroPlaceholder": "请输入一句话介绍（最少8个字符）",
+      "detailIntro": "详细介绍",
+      "detailIntroPlaceholder": "请输入详细介绍（最少10个字符）",
+      "providedServices": "提供的服务",
+      "serviceAreas": "服务区域",
+      "required": "*",
+      "requiredField": "必填",
+      "minLength8": "请至少输入8个字符",
+      "minLength10": "请至少输入10个字符",
+      "minCareer": "工作经验必须至少0年",
+      "save": "保存更改",
+      "cancel": "取消",
+      "successTitle": "个人资料更新完成",
+      "successMessage": "个人资料已成功更新。",
+      "errorTitle": "个人资料更新失败",
+      "errorMessage": "更新失败。",
+      "generalError": "发生错误。",
+      "confirm": "确认"
+    }
   },
   "search": {
     "title": "搜索搬家公司",
@@ -329,6 +356,19 @@
     "yearsMobile": "年",
     "casesMobile": "",
     "confirmedMobile": "完成",
+    "myPage": {
+      "loading": "加载中...",
+      "retry": "重试",
+      "profileNotFound": "找不到个人资料信息。",
+      "editProfile": "编辑我的个人资料",
+      "editBasicInfo": "编辑基本信息",
+      "activityStatus": "活动状态",
+      "inProgress": "进行中",
+      "reviews": "评论",
+      "totalExperience": "总经验",
+      "providedServices": "提供的服务",
+      "serviceAreas": "服务区域"
+    },
     "serviceTypes": {
       "small": "小型搬家",
       "home": "家庭搬家",

--- a/src/pageComponents/moverMyPage/MoverMyPage.tsx
+++ b/src/pageComponents/moverMyPage/MoverMyPage.tsx
@@ -8,7 +8,7 @@ import editIcon from "@/assets/icon/edit/icon-edit.png";
 import editGrayIcon from "@/assets/icon/edit/icon-edit-gray.svg";
 import { CircleTextLabel } from "@/components/common/chips/CircleTextLabel";
 import Favorite from "@/components/common/button/Favorite";
-import { getRegionTranslation } from "@/lib/utils/translationUtils";
+import { getRegionTranslation, getServiceTypeTranslation } from "@/lib/utils/translationUtils";
 import { useRouter } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
 import ReviewAvg from "@/components/searchMover/[id]/ReviewAvg";
@@ -153,7 +153,7 @@ const MoverMyPage = () => {
   if (isLoading) {
     return (
       <div className="flex min-h-screen w-full items-center justify-center bg-bg-primary">
-        <div className="text-lg">로딩 중...</div>
+        <div className="text-lg">{t("myPage.loading")}</div>
       </div>
     );
   }
@@ -167,7 +167,7 @@ const MoverMyPage = () => {
             onClick={() => window.location.reload()} 
             className="px-4 py-2 bg-primary-400 text-white rounded-lg hover:bg-primary-500"
           >
-            다시 시도
+            {t("myPage.retry")}
           </button>
         </div>
       </div>
@@ -177,7 +177,7 @@ const MoverMyPage = () => {
   if (!profile) {
     return (
       <div className="flex min-h-screen w-full items-center justify-center bg-bg-primary">
-        <div className="text-lg">프로필 정보를 찾을 수 없습니다.</div>
+        <div className="text-lg">{t("myPage.profileNotFound")}</div>
       </div>
     );
   }
@@ -248,7 +248,7 @@ const MoverMyPage = () => {
                   onClick={() => router.push(`/${locale}/profile/edit`)}
                   className="flex items-center justify-center gap-2 px-6 py-3 w-full h-16 bg-primary-400 text-white font-semibold rounded-24 hover:bg-primary-500 transition-colors shadow-md cursor-pointer"
                 >
-                  내 프로필 수정
+                  {t("myPage.editProfile")}
                   <Image src={editIcon} alt="edit-icon" className="w-6 h-6" />
                 </button>
                 <button 
@@ -256,7 +256,7 @@ const MoverMyPage = () => {
                   className="self-stretch h-16 p-4 w-full rounded-24 outline outline-1 outline-offset-[-1px] outline-gray-200 inline-flex justify-center items-center hover:bg-bg-secondary transition-colors cursor-pointer"
                 >
                   <div className="flex justify-start items-center gap-1.5">
-                    <div className="text-center justify-center text-neutral-400 text-lg font-semibold leading-relaxed">기본 정보 수정</div>
+                    <div className="text-center justify-center text-neutral-400 text-lg font-semibold leading-relaxed">{t("myPage.editBasicInfo")}</div>
                     <div className="w-6 h-6 relative overflow-hidden">
                       <Image src={editGrayIcon} alt="edit-icon" className="w-6 h-6" />
                     </div>
@@ -270,7 +270,7 @@ const MoverMyPage = () => {
                   className="flex-1 h-16 p-4 rounded-24 outline outline-1 outline-offset-[-1px] outline-gray-200 inline-flex justify-center items-center hover:bg-bg-secondary transition-colors cursor-pointer"
                 >
                   <div className="flex justify-start items-center gap-1.5">
-                    <div className="text-center justify-center text-neutral-400 text-lg font-semibold leading-relaxed">기본 정보 수정</div>
+                    <div className="text-center justify-center text-neutral-400 text-lg font-semibold leading-relaxed">{t("myPage.editBasicInfo")}</div>
                     <div className="w-6 h-6 relative overflow-hidden">
                       <Image src={editGrayIcon} alt="edit-icon" className="w-6 h-6" />
                     </div>
@@ -280,40 +280,40 @@ const MoverMyPage = () => {
                   onClick={() => router.push(`/${locale}/profile/edit`)}
                   className="flex items-center justify-center gap-2 px-6 py-3 flex-1 h-16 bg-primary-400 text-white font-semibold rounded-24 hover:bg-primary-500 transition-colors shadow-md cursor-pointer"
                 >
-                  내 프로필 수정
+                  {t("myPage.editProfile")}
                   <Image src={editIcon} alt="edit-icon" className="w-6 h-6" />
                 </button>
               </div>
               
               <div className="self-stretch flex flex-col justify-start items-start gap-4">
-                  <div className="self-stretch justify-start text-neutral-800 text-xl font-semibold leading-loose">활동 현황</div>
+                  <div className="self-stretch justify-start text-neutral-800 text-xl font-semibold leading-loose">{t("myPage.activityStatus")}</div>
                   <div className="self-stretch h-28 px-40 bg-bg-secondary rounded-24 border border-gray-200 inline-flex justify-between items-center">
-                    <div className="w-14 inline-flex flex-col justify-start items-center gap-1">
-                      <div className="self-stretch text-center justify-start text-gray-800 text-base font-normal leading-relaxed">진행</div>
+                    <div className="flex-1 inline-flex flex-col justify-start items-center gap-1">
+                      <div className="self-stretch text-center justify-start text-gray-800 text-base font-normal leading-relaxed whitespace-nowrap">{t("myPage.inProgress")}</div>
                       <div className="self-stretch text-center justify-center text-primary-400 text-xl font-bold leading-loose">{profile.completedCount}건</div>
                     </div>
-                    <div className="w-24 inline-flex flex-col justify-start items-center gap-1">
-                      <div className="text-center justify-start text-gray-800 text-base font-normal leading-relaxed">리뷰</div>
+                    <div className="flex-1 inline-flex flex-col justify-start items-center gap-1">
+                      <div className="text-center justify-start text-gray-800 text-base font-normal leading-relaxed whitespace-nowrap">{t("myPage.reviews")}</div>
                       <div className="inline-flex justify-start items-center gap-1.5">
                         <div className="justify-center text-primary-400 text-xl font-bold leading-loose">
                           {profile.avgRating.toFixed(1)}
                         </div>
                       </div>
                     </div>
-                    <div className="w-16 inline-flex flex-col justify-start items-center gap-1">
-                      <div className="self-stretch text-center justify-start text-gray-800 text-base font-normal leading-relaxed whitespace-nowrap">총 경력</div>
+                    <div className="flex-1 inline-flex flex-col justify-start items-center gap-1">
+                      <div className="self-stretch text-center justify-start text-gray-800 text-base font-normal leading-relaxed whitespace-nowrap">{t("myPage.totalExperience")}</div>
                       <div className="self-stretch text-center justify-center text-primary-400 text-xl font-bold leading-loose">{profile.experience}년</div>
                     </div>
                   </div>
                 </div>
             </div>
             <div className="flex flex-col justify-start items-start gap-4">
-              <div className="justify-start text-neutral-800 text-xl font-semibold leading-loose">제공 서비스</div>
+              <div className="justify-start text-neutral-800 text-xl font-semibold leading-loose">{t("myPage.providedServices")}</div>
               <div className="inline-flex items-start justify-start gap-1.5 lg:gap-3">
                 {profile.serviceTypes.map((serviceType: any, idx: number) => (
                   <CircleTextLabel
                     key={idx}
-                    text={serviceType.service?.name || serviceType}
+                    text={getServiceTypeTranslation(serviceType.service?.name || serviceType, t)}
                     clickAble={false}
                     hasBorder1={true}
                     hasBorder2={true}
@@ -322,7 +322,7 @@ const MoverMyPage = () => {
               </div>
             </div>
             <div className="flex flex-col justify-start items-start gap-4">
-              <div className="justify-start text-neutral-800 text-xl font-semibold leading-loose">서비스 가능 지역</div>
+              <div className="justify-start text-neutral-800 text-xl font-semibold leading-loose">{t("myPage.serviceAreas")}</div>
               <div className="flex flex-wrap items-start gap-1.5 lg:gap-3 max-w-full">
                 {(profileDetail.currentAreas.length > 0 ? profileDetail.currentAreas : profile.serviceRegions).map((region: any, idx: number) => (
                   <CircleTextLabel
@@ -354,7 +354,7 @@ const MoverMyPage = () => {
               onClick={() => router.push(`/${locale}/profile/edit`)}
               className="flex items-center justify-center gap-2 px-6 py-3 lg:w-[283px] lg:h-16 bg-primary-400 text-white font-semibold rounded-24 hover:bg-primary-500 transition-colors shadow-md cursor-pointer"
             >
-              내 프로필 수정
+              {t("myPage.editProfile")}
               <Image src={editIcon} alt="edit-icon" className="w-6 h-6" />
             </button>
             <button 
@@ -362,7 +362,7 @@ const MoverMyPage = () => {
               className="self-stretch h-16 p-4 lg:w-[283px] rounded-24 outline outline-1 outline-offset-[-1px] outline-gray-200 inline-flex justify-center items-center hover:bg-bg-secondary transition-colors cursor-pointer"
             >
               <div className="flex justify-start items-center gap-1.5">
-                <div className="text-center justify-center text-neutral-400 text-lg font-semibold leading-relaxed">기본 정보 수정</div>
+                <div className="text-center justify-center text-neutral-400 text-lg font-semibold leading-relaxed">{t("myPage.editBasicInfo")}</div>
                 <div className="w-6 h-6 relative overflow-hidden">
                   <Image src={editGrayIcon} alt="edit-icon" className="w-6 h-6" />
                 </div>

--- a/src/pageComponents/moverMyPage/MoverMyPage.tsx
+++ b/src/pageComponents/moverMyPage/MoverMyPage.tsx
@@ -290,7 +290,7 @@ const MoverMyPage = () => {
                   <div className="self-stretch h-28 px-40 bg-bg-secondary rounded-24 border border-gray-200 inline-flex justify-between items-center">
                     <div className="flex-1 inline-flex flex-col justify-start items-center gap-1">
                       <div className="self-stretch text-center justify-start text-gray-800 text-base font-normal leading-relaxed whitespace-nowrap">{t("myPage.inProgress")}</div>
-                      <div className="self-stretch text-center justify-center text-primary-400 text-xl font-bold leading-loose">{profile.completedCount}건</div>
+                      <div className="self-stretch text-center justify-center text-primary-400 text-xl font-bold leading-loose">{profile.completedCount} {t("cases")}</div>
                     </div>
                     <div className="flex-1 inline-flex flex-col justify-start items-center gap-1">
                       <div className="text-center justify-start text-gray-800 text-base font-normal leading-relaxed whitespace-nowrap">{t("myPage.reviews")}</div>
@@ -302,7 +302,7 @@ const MoverMyPage = () => {
                     </div>
                     <div className="flex-1 inline-flex flex-col justify-start items-center gap-1">
                       <div className="self-stretch text-center justify-start text-gray-800 text-base font-normal leading-relaxed whitespace-nowrap">{t("myPage.totalExperience")}</div>
-                      <div className="self-stretch text-center justify-center text-primary-400 text-xl font-bold leading-loose">{profile.experience}년</div>
+                      <div className="self-stretch text-center justify-center text-primary-400 text-xl font-bold leading-loose">{profile.experience} {t("years")}</div>
                     </div>
                   </div>
                 </div>

--- a/src/pageComponents/moverMyPage/edit/EditPage.tsx
+++ b/src/pageComponents/moverMyPage/edit/EditPage.tsx
@@ -100,30 +100,30 @@ const EditPage = () => {
           <form onSubmit={handleSubmit(onSubmit)} className="grid grid-cols-1 gap-x-40 gap-y-8 lg:grid-cols-2">
             <div className="flex flex-col gap-8">
               <div className="flex flex-col gap-4">
-                <div className="text-base leading-relaxed font-semibold text-zinc-800 lg:text-lg">이름</div>
+                <div className="text-base leading-relaxed font-semibold text-zinc-800 lg:text-lg">{t("name")}</div>
                 <TextInput
                   name="name"
                   rules={validationRules.name}
-                  placeholder="이름을 입력해주세요"
+                  placeholder={t("namePlaceholder")}
                   inputClassName="w-full lg:w-[500px] p-3.5 bg-white rounded-2xl outline outline-[0.5px] outline-offset-[-0.5px] outline-neutral-200 text-base !text-black"
                   wrapperClassName="w-full max-w-[560px] sm:!w-full lg:max-w-none lg:w-[500px]"
                 />
               </div>
               <div className="flex flex-col gap-4">
-                <div className="text-base leading-relaxed font-semibold text-zinc-800 lg:text-lg">이메일</div>
+                <div className="text-base leading-relaxed font-semibold text-zinc-800 lg:text-lg">{t("email")}</div>
                 <TextInput
                   name="email"
                   inputClassName="w-full lg:w-[500px] p-3.5 bg-white rounded-2xl outline outline-1 outline-offset-[-1px] outline-neutral-200 text-base text-[#999999] pointer-events-none bg-gray-100"
                   wrapperClassName="w-full max-w-[560px] sm:!w-full lg:max-w-none lg:w-[500px]"
-                  placeholder="이메일을 입력해주세요"
+                  placeholder={t("emailPlaceholder")}
                 />
               </div>
               <div className="flex flex-col gap-4">
-                <div className="text-base leading-relaxed font-semibold text-zinc-800 lg:text-lg">전화번호</div>
+                <div className="text-base leading-relaxed font-semibold text-zinc-800 lg:text-lg">{t("phone")}</div>
                 <TextInput
                   name="phone"
                   rules={validationRules.phoneNumber}
-                  placeholder="전화번호를 입력해주세요"
+                  placeholder={t("phonePlaceholder")}
                   inputClassName="w-full lg:w-[500px] p-3.5 bg-white rounded-2xl outline outline-[0.5px] outline-offset-[-0.5px] outline-neutral-200 text-base !text-black"
                   wrapperClassName="w-full max-w-[560px] sm:!w-full lg:max-w-none lg:w-[500px]"
                 />
@@ -131,14 +131,14 @@ const EditPage = () => {
             </div>
             <div className="flex flex-col gap-8">
               <div className="flex flex-col gap-4">
-                <div className="text-base leading-relaxed font-semibold text-zinc-800 lg:text-lg">현재 비밀번호</div>
+                <div className="text-base leading-relaxed font-semibold text-zinc-800 lg:text-lg">{t("currentPassword")}</div>
                 <PasswordInput
                   name="currentPassword"
-                  placeholder="현재 비밀번호를 입력해주세요"
+                  placeholder={t("currentPasswordPlaceholder")}
                   rules={{
                     validate: (value) => {
                       if (watch("newPassword") || watch("newPasswordConfirm")) {
-                        return value ? true : "현재 비밀번호를 입력해주세요";
+                        return value ? true : t("currentPasswordRequired");
                       }
                       return true;
                     },
@@ -148,14 +148,14 @@ const EditPage = () => {
                 />
               </div>
               <div className="flex flex-col gap-4">
-                <div className="text-base leading-relaxed font-semibold text-zinc-800 lg:text-lg">새 비밀번호</div>
+                <div className="text-base leading-relaxed font-semibold text-zinc-800 lg:text-lg">{t("newPassword")}</div>
                 <PasswordInput
                   name="newPassword"
-                  placeholder="새 비밀번호를 입력해주세요"
+                  placeholder={t("newPasswordPlaceholder")}
                   rules={{
                     validate: (value) => {
                       if (watch("currentPassword") || watch("newPasswordConfirm")) {
-                        if (!value) return "새 비밀번호를 입력해주세요";
+                        if (!value) return t("newPasswordRequired");
                         return validationRules.password.validate(value);
                       }
                       return true;
@@ -166,15 +166,15 @@ const EditPage = () => {
                 />
               </div>
               <div className="flex flex-col gap-4">
-                <div className="text-base leading-relaxed font-semibold text-zinc-800 lg:text-lg">새 비밀번호 확인</div>
+                <div className="text-base leading-relaxed font-semibold text-zinc-800 lg:text-lg">{t("confirmNewPassword")}</div>
                 <PasswordInput
                   name="newPasswordConfirm"
-                  placeholder="새 비밀번호를 다시 한번 입력해주세요"
+                  placeholder={t("confirmNewPasswordPlaceholder")}
                   rules={{
                     validate: (value) => {
                       if (watch("currentPassword") || watch("newPassword")) {
-                        if (!value) return "새 비밀번호 확인을 입력해주세요";
-                        if (value !== getValues("newPassword")) return "새 비밀번호가 일치하지 않습니다.";
+                        if (!value) return t("confirmNewPasswordRequired");
+                        if (value !== getValues("newPassword")) return t("passwordMismatch");
                       }
                       return true;
                     },
@@ -190,7 +190,7 @@ const EditPage = () => {
                 className="h-[54px] w-full rounded-xl px-6 py-4 text-base font-semibold text-neutral-400 shadow-[4px_4px_10px_0px_rgba(195,217,242,0.20)] outline outline-1 outline-offset-[-1px] outline-stone-300 lg:h-[60px] lg:w-[240px]"
                 onClick={() => router.back()}
               >
-                취소
+                {t("cancel")}
               </button>
               <Button
                 variant="solid"
@@ -199,7 +199,7 @@ const EditPage = () => {
                 disabled={!requiredFilled}
                 onClick={handleSubmit(onSubmit)}
               >
-                수정하기
+                {t("save")}
               </Button>
             </div>
             {formError && <div className="col-span-1 mt-2 text-sm text-red-500 lg:col-span-2">{formError}</div>}

--- a/src/pageComponents/profile/edit/MoverEditPage.tsx
+++ b/src/pageComponents/profile/edit/MoverEditPage.tsx
@@ -11,8 +11,9 @@ import moverprofileMd from "@/assets/img/mascot/moverprofile-md.png";
 import userApi from "@/lib/api/user.api";
 import { useAuth } from "@/providers/AuthProvider";
 import { useRouter } from "next/navigation";
-import { useLocale } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { regionLabelMap } from "@/lib/utils/regionMapping";
+import { getServiceTypeTranslation, getRegionTranslation } from "@/lib/utils/translationUtils";
 import { useModal } from "@/components/common/modal/ModalContext";
 
 const SERVICE_OPTIONS = ["소형이사", "가정이사", "사무실이사"];
@@ -75,6 +76,8 @@ export default function MoverEditPage() {
   const router = useRouter();
   const { getUser } = useAuth();
   const locale = useLocale();
+  const t = useTranslations("profile");
+  const moverT = useTranslations("mover");
   const { open, close } = useModal();
   const [services, setServices] = useState<string[]>([]);
   const [regions, setRegions] = useState<string[]>([]);
@@ -184,11 +187,11 @@ export default function MoverEditPage() {
       if (result.success) {
         await getUser();
         open({
-          title: "프로필 수정 완료",
-          children: <div>프로필 수정이 완료되었습니다.</div>,
+          title: t("edit.successTitle"),
+          children: <div>{t("edit.successMessage")}</div>,
           buttons: [
             {
-              text: "확인",
+              text: t("edit.confirm"),
               onClick: () => {
                 close();
                 router.push(`/${locale}/moverMyPage`);
@@ -198,16 +201,16 @@ export default function MoverEditPage() {
         });
       } else {
         open({
-          title: "프로필 수정 실패",
-          children: <div>{result.message || "수정에 실패했습니다."}</div>,
-          buttons: [{ text: "확인", onClick: () => close() }],
+          title: t("edit.errorTitle"),
+          children: <div>{result.message || t("edit.errorMessage")}</div>,
+          buttons: [{ text: t("edit.confirm"), onClick: () => close() }],
         });
       }
     } catch (e) {
       open({
-        title: "프로필 수정 실패",
-        children: <div>오류가 발생했습니다.</div>,
-        buttons: [{ text: "확인", onClick: () => close() }],
+        title: t("edit.errorTitle"),
+        children: <div>{t("edit.generalError")}</div>,
+        buttons: [{ text: t("edit.confirm"), onClick: () => close() }],
       });
     }
   };
@@ -221,7 +224,7 @@ export default function MoverEditPage() {
         >
           <div className="flex flex-col items-start justify-center gap-4 self-stretch lg:gap-8">
             <div className="justify-center text-lg leading-relaxed font-bold text-neutral-800 lg:text-3xl lg:leading-10 lg:font-semibold">
-              프로필 수정
+              {t("edit.title")}
             </div>
           </div>
           <div className="mx-auto h-0 w-[327px] self-stretch outline outline-1 outline-offset-[-0.5px] outline-zinc-100 lg:w-full" />
@@ -229,7 +232,7 @@ export default function MoverEditPage() {
             <div className="flex w-full flex-col gap-8 lg:w-[500px]">
               <div className="flex flex-col gap-4">
                 <div className="text-base leading-relaxed font-semibold text-zinc-800 lg:text-xl lg:leading-loose">
-                  프로필 이미지
+                  {t("edit.profileImage")}
                 </div>
                 <div className="flex items-center gap-4">
                   <input
@@ -255,17 +258,17 @@ export default function MoverEditPage() {
               <div className="flex flex-col gap-4">
                 <div className="inline-flex items-center gap-1">
                   <div className="text-base leading-relaxed font-semibold text-zinc-800 lg:text-xl lg:leading-loose">
-                    별명
+                    {t("edit.nickname")}
                   </div>
                   <div className="text-base leading-relaxed font-semibold text-red-500 lg:text-xl lg:leading-loose">
-                    *
+                    {t("edit.required")}
                   </div>
                 </div>
                 <div className="w-[327px] lg:w-full">
                   <TextInput
                     name="nickname"
-                    placeholder="별명을 입력하세요"
-                    rules={{ required: "필수 입력" }}
+                    placeholder={t("edit.nicknamePlaceholder")}
+                    rules={{ required: t("edit.requiredField") }}
                     inputClassName="w-[327px] h-[54px] lg:w-[500px] lg:h-[64px]"
                     wrapperClassName="w-[327px] lg:w-[500px]"
                   />
@@ -275,17 +278,17 @@ export default function MoverEditPage() {
               <div className="flex flex-col gap-4">
                 <div className="inline-flex items-center gap-1">
                   <div className="text-base leading-relaxed font-semibold text-zinc-800 lg:text-xl lg:leading-loose">
-                    경력
+                    {t("edit.career")}
                   </div>
                   <div className="text-base leading-relaxed font-semibold text-red-500 lg:text-xl lg:leading-loose">
-                    *
+                    {t("edit.required")}
                   </div>
                 </div>
                 <div className="w-[327px] lg:w-full">
                   <TextInput
                     name="career"
-                    placeholder="ex) 8"
-                    rules={{ required: "필수 입력", min: { value: 0, message: "경력은 0년 이상이어야 합니다" } }}
+                    placeholder={t("edit.careerPlaceholder")}
+                    rules={{ required: t("edit.requiredField"), min: { value: 0, message: t("edit.minCareer") } }}
                     inputClassName="w-[327px] h-[54px] lg:w-[500px] lg:h-[64px]"
                     wrapperClassName="w-[327px] lg:w-[500px]"
                   />
@@ -295,17 +298,17 @@ export default function MoverEditPage() {
               <div className="flex flex-col gap-4">
                 <div className="inline-flex items-center gap-1">
                   <div className="text-base leading-relaxed font-semibold text-zinc-800 lg:text-xl lg:leading-loose">
-                    한 줄 소개
+                    {t("edit.shortIntro")}
                   </div>
                   <div className="text-base leading-relaxed font-semibold text-red-500 lg:text-xl lg:leading-loose">
-                    *
+                    {t("edit.required")}
                   </div>
                 </div>
                 <div className="w-[327px] lg:w-full">
                   <TextInput
                     name="intro"
-                    placeholder="한 줄 소개를 입력하세요 (최소 8자)"
-                    rules={{ required: "필수 입력", minLength: { value: 8, message: "8자 이상 입력해주세요" } }}
+                    placeholder={t("edit.shortIntroPlaceholder")}
+                    rules={{ required: t("edit.requiredField"), minLength: { value: 8, message: t("edit.minLength8") } }}
                     inputClassName="w-[327px] h-[54px] lg:w-[500px] lg:h-[64px]"
                     wrapperClassName="w-[327px] lg:w-[500px]"
                   />
@@ -316,17 +319,17 @@ export default function MoverEditPage() {
               <div className="flex flex-col gap-4">
                 <div className="inline-flex items-center gap-1">
                   <div className="text-base leading-relaxed font-semibold text-zinc-800 lg:text-xl lg:leading-loose">
-                    상세 설명
+                    {t("edit.detailIntro")}
                   </div>
                   <div className="text-base leading-relaxed font-semibold text-red-500 lg:text-xl lg:leading-loose">
-                    *
+                    {t("edit.required")}
                   </div>
                 </div>
                 <div className="w-[327px] lg:w-full">
                   <TextAreaInput
                     name="desc"
-                    placeholder="상세 설명을 입력하세요 (최소 10자)"
-                    rules={{ required: "필수 입력", minLength: { value: 10, message: "10자 이상 입력해주세요" } }}
+                    placeholder={t("edit.detailIntroPlaceholder")}
+                    rules={{ required: t("edit.requiredField"), minLength: { value: 10, message: t("edit.minLength10") } }}
                     textareaClassName="w-[327px] h-[100px] lg:w-[500px] lg:h-[160px] border border-[1px] !border-[#E6E6E6]"
                     wrapperClassName="w-[327px] lg:w-[500px]"
                   />
@@ -336,17 +339,17 @@ export default function MoverEditPage() {
               <div className="flex flex-col gap-4">
                 <div className="inline-flex items-center gap-1">
                   <div className="text-base leading-relaxed font-semibold text-zinc-800 lg:text-xl lg:leading-loose">
-                    제공 서비스
+                    {t("edit.providedServices")}
                   </div>
                   <div className="text-base leading-relaxed font-semibold text-red-500 lg:text-xl lg:leading-loose">
-                    *
+                    {t("edit.required")}
                   </div>
                 </div>
-                <div className="inline-flex items-start justify-start gap-1.5 lg:gap-3">
+                <div className="flex flex-wrap items-start gap-1.5 lg:gap-3">
                   {SERVICE_OPTIONS.map((service) => (
                     <CircleTextLabel
                       key={service}
-                      text={service}
+                      text={getServiceTypeTranslation(service, moverT)}
                       clickAble={true}
                       isSelected={services.includes(service)}
                       onClick={() =>
@@ -362,18 +365,18 @@ export default function MoverEditPage() {
               <div className="flex flex-col gap-4">
                 <div className="inline-flex items-center gap-1">
                   <div className="text-base leading-relaxed font-semibold text-zinc-800 lg:text-xl lg:leading-loose">
-                    서비스 가능 지역
+                    {t("edit.serviceAreas")}
                   </div>
                   <div className="text-base leading-relaxed font-semibold text-red-500 lg:text-xl lg:leading-loose">
-                    *
+                    {t("edit.required")}
                   </div>
                 </div>
                 <div className="flex flex-col gap-4">
-                  <div className="grid w-full grid-cols-5 gap-2 lg:gap-3.5">
+                  <div className="flex flex-wrap items-start gap-2 lg:gap-3.5">
                     {REGION_OPTIONS.map((region) => (
                       <CircleTextLabel
                         key={region}
-                        text={region}
+                        text={getRegionTranslation(regionTypeMapping[region], moverT)}
                         clickAble={true}
                         isSelected={regions.includes(region)}
                         onClick={() =>
@@ -397,7 +400,7 @@ export default function MoverEditPage() {
                   disabled={!allFilled}
                   state={allFilled ? "default" : "disabled"}
                 >
-                  <div className="justify-center text-center">수정하기</div>
+                  <div className="justify-center text-center">{t("edit.save")}</div>
                 </Button>
                 <Button
                   variant="outlined"
@@ -407,7 +410,7 @@ export default function MoverEditPage() {
                   className="!hover:bg-white !focus:bg-white !active:bg-white order-2 items-center justify-center rounded-2xl border border-[1px] !border-[#C4C4C4] bg-white px-6 py-4 text-base leading-relaxed font-semibold !text-[#C4C4C4] shadow-none outline outline-1 outline-offset-[-1px] lg:order-1"
                   onClick={() => window.history.back()}
                 >
-                  <div className="justify-center text-center">취소</div>
+                  <div className="justify-center text-center">{t("edit.cancel")}</div>
                 </Button>
               </div>
             </div>


### PR DESCRIPTION
## ✨ 작업 개요
- 기사님 기본정보 수정 페이지, 기사님 마이페이지, 기사님 프로필 수정 페이지에 다국어 기능을 구현했습니다.

## ✅ 주요 작업 내용
기사님 기본정보 수정 페이지 다국어 구현
- useTranslations("edit") 훅 사용
- 제목, 라벨, 플레이스홀더, 버튼 텍스트, 에러/성공 메시지 번역 키 적용

기사님 마이페이지 다국어 구현
- useTranslations("mover") 훅 사용
- 로딩 메시지, 버튼 텍스트, 섹션 제목 번역 키 적용

기사님 프로필 수정 페이지 다국어 구현
- useTranslations("profile") 및 useTranslations("mover") 훅 사용
- 폼 라벨, 플레이스홀더, 검증 메시지, 모달 메시지 번역 키 적용
---
- ko.json, en.json, zh.json에 새로운 번역 키 추가

## 🔄 관련 이슈
Closes #217 

## 📸 스크린샷 (선택)
<img width="1565" height="1261" alt="스크린샷 2025-07-28 172510" src="https://github.com/user-attachments/assets/9344e45c-d821-40f0-aa36-a88d7a54b2d2" />
<img width="1425" height="1022" alt="스크린샷 2025-07-28 172531" src="https://github.com/user-attachments/assets/5ca72cd9-20f7-4be9-9b7b-95448dbae79a" />
<img width="2078" height="1182" alt="스크린샷 2025-07-28 172557" src="https://github.com/user-attachments/assets/2a8f05e4-11df-47d3-a1ae-613685efdd8d" />
<img width="1418" height="1158" alt="스크린샷 2025-07-28 172620" src="https://github.com/user-attachments/assets/c1ffcdc2-d3ff-452b-8e0c-5da88acf20ed" />
<img width="1376" height="951" alt="스크린샷 2025-07-28 172643" src="https://github.com/user-attachments/assets/993109f1-9fec-4fcf-95fc-dd0fcc19e95c" />
<img width="2102" height="1162" alt="스크린샷 2025-07-28 172659" src="https://github.com/user-attachments/assets/302d09c9-1cb8-4ac6-aa64-ab0621aa82a5" />


## 🧪 테스트 방법 (선택)
- [ ] 기사님 기본정보 수정 페이지 진입 시 모든 텍스트가 번역 키로 표시되는지 확인
- [ ] 기사님 마이페이지에서 제공 서비스 및 서비스 가능 지역 chip이 번역되는지 확인
- [ ] 언어 변경 시 (한국어/영어/중국어) 모든 페이지에서 일관된 번역이 적용되는지 확인

## 📝 비고
- getServiceTypeTranslation() 및 getRegionTranslation() 유틸리티 함수를 활용하여 일관된 번역 처리
- 반응형 디자인 개선으로 다국어 환경에서도 안정적인 UI 제공