### PR TITLE
[#202] [#221] Feat/notification 알림 관련 파일 다국어 기능 구현 및 비회원 알림 비요청 처리.

### DIFF
--- a/src/components/common/dropdown/UserActionDropdown.tsx
+++ b/src/components/common/dropdown/UserActionDropdown.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useRef } from "react";
 import { IoClose } from "react-icons/io5";
+import { useTranslations } from "next-intl";
 
 interface IUserActionDropdownProps {
   type: "alert" | "info";
@@ -34,10 +35,12 @@ const DropdownHeader = ({
   title,
   onClose,
   showCloseButton = true,
+  closeLabel,
 }: {
   title: string;
   onClose?: () => void;
   showCloseButton?: boolean;
+  closeLabel?: string;
 }) => (
   <div className="inline-flex w-full items-center justify-between bg-white py-3.5 pr-3 pl-4 cursor-default">
     <div className="flex items-center justify-start">
@@ -47,7 +50,7 @@ const DropdownHeader = ({
       <button
         onClick={onClose}
         className="flex h-6 w-6 items-center justify-center text-gray-400 transition-colors hover:text-gray-600 cursor-pointer"
-        aria-label="닫기"
+        aria-label={closeLabel}
       >
         <IoClose size={20} />
       </button>
@@ -57,6 +60,7 @@ const DropdownHeader = ({
 
 const UserActionDropdown = ({ type, onClose, isOpen, children, name, triggerRef }: IUserActionDropdownProps) => {
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const t = useTranslations("gnb");
 
   // ESC 키로 닫기
   useEffect(() => {
@@ -104,12 +108,12 @@ const UserActionDropdown = ({ type, onClose, isOpen, children, name, triggerRef 
     <div className="" ref={dropdownRef}>
       {type === "alert" ? (
         <DropdownContainer className="absolute -right-30 w-78 md:-right-7 lg:w-[359px]" rounded="rounded-24">
-          <DropdownHeader title="알림" onClose={onClose} />
+          <DropdownHeader title={t("notification")} onClose={onClose} closeLabel={t("close")} />
           {children}
         </DropdownContainer>
       ) : (
         <DropdownContainer className="w-38 lg:w-62" rounded="rounded-16">
-          <DropdownHeader title={`${name || "사용자"} 고객님`} onClose={onClose} showCloseButton={false} />
+          <DropdownHeader title={`${name || t("defaultUser")} ${t("userSuffix.customer")}`} onClose={onClose} showCloseButton={false} closeLabel={t("close")} />
           {children}
         </DropdownContainer>
       )}

--- a/src/components/common/gnb/GnbActions.tsx
+++ b/src/components/common/gnb/GnbActions.tsx
@@ -127,11 +127,13 @@ export const GnbActions = ({ userRole, userName, deviceType, toggleSideMenu, isS
     };
   }, [isProfileOpen]);
 
+  // 로그인한 사용자만 알림 데이터 패칭
   useEffect(() => {
-    // 헤더가 보일 때(마운트 시) 최신 알림 1개만 받아와서 hasUnread만 갱신
-    fetchNotifications(1, 0);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    if (userRole !== "GUEST") {
+      // 헤더가 보일 때(마운트 시) 최신 알림 1개만 받아와서 hasUnread만 갱신
+      fetchNotifications(1, 0);
+    }
+  }, [userRole, fetchNotifications]);
 
   return (
     <div className="flex items-center gap-4">

--- a/src/components/common/gnb/GnbActions.tsx
+++ b/src/components/common/gnb/GnbActions.tsx
@@ -12,14 +12,15 @@ import NotificationList from "@/components/notification/NotificationList";
 import UserActionDropdown from "../dropdown/UserActionDropdown";
 import { useNotificationStore } from "@/stores/notificationStore";
 import { useAuth } from "@/providers/AuthProvider";
+import { useTranslations } from "next-intl";
 
 const USER_ACTION_LIST = [
   {
-    label: "프로필 수정",
+    label: "gnb.userActions.editProfile",
     href: "/profile/edit",
   },
   {
-    label: "찜한 기사님",
+    label: "gnb.userActions.favoriteDrivers",
     href: "/user/favorite",
   },
 ];
@@ -27,11 +28,11 @@ const USER_ACTION_LIST = [
 // TODO :  이부분은 기사님쪽에 맞춰서 수정 필요
 const MOVER_USER_ACTION_LIST = [
   {
-    label: "프로필 수정",
+    label: "gnb.userActions.editProfile",
     href: "/profile/edit",
   },
   {
-    label: "마이페이지",
+    label: "gnb.userActions.myPage",
     href: "/moverMyPage",
   },
   {
@@ -54,6 +55,7 @@ interface IGnbActionsProps {
 
 export const GnbActions = ({ userRole, userName, deviceType, toggleSideMenu, isSideMenuOpen }: IGnbActionsProps) => {
   const { logout } = useAuth();
+  const t = useTranslations("gnb");
 
   const [isNotificationOpen, setIsNotificationOpen] = useState(false);
   const [isProfileOpen, setIsProfileOpen] = useState(false);
@@ -141,22 +143,25 @@ export const GnbActions = ({ userRole, userName, deviceType, toggleSideMenu, isS
           href="/userSignin"
           className="bg-primary-400 hover:bg-primary-500 rounded-md px-4 py-2 text-sm font-medium text-white transition-colors"
         >
-          로그인
+          {t("login")}
         </Link>
       )}
 
       {userRole !== "GUEST" && (
         <>
           {/* 알림 버튼 */}
-          <div className="hover:text-black-400 cursor-pointer p-2 text-gray-400 transition-colors" aria-label="알림">
+          <div
+            className="hover:text-black-400 cursor-pointer p-2 text-gray-400 transition-colors"
+            aria-label={t("notification")}
+          >
             <div className="relative h-6 w-6">
               <button
                 ref={notificationButtonRef}
                 onClick={handleNotificationClick}
                 className="cursor-pointer"
-                aria-label="알림"
+                aria-label={t("notification")}
               >
-                <Image src={notification} alt="알림" width={24} height={24} />
+                <Image src={notification} alt={t("notification")} width={24} height={24} />
                 {hasUnread && <div className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-red-500"></div>}
               </button>
               <UserActionDropdown
@@ -176,9 +181,9 @@ export const GnbActions = ({ userRole, userName, deviceType, toggleSideMenu, isS
               ref={profileButtonRef}
               onClick={handleProfileClick}
               className="flex cursor-pointer gap-3 p-2 text-black"
-              aria-label="프로필"
+              aria-label={t("profile")}
             >
-              <Image src={profile} alt="프로필" width={24} height={24} />
+              <Image src={profile} alt={t("profile")} width={24} height={24} />
               <div className="hidden lg:block">{userName}</div>
             </button>
 
@@ -190,18 +195,18 @@ export const GnbActions = ({ userRole, userName, deviceType, toggleSideMenu, isS
               >
                 <nav className="flex flex-col items-start justify-start border-b border-[#F2F2F2]">
                   <span className="w-full px-2 py-2 text-left text-lg">
-                    {userName} {userRole === "CUSTOMER" ? "고객님" : "기사님"}
+                    {userName} {userRole === "CUSTOMER" ? t("userSuffix.customer") : t("userSuffix.driver")}
                   </span>
                   <ul className="flex w-full flex-col">
                     {userRole === "CUSTOMER"
                       ? USER_ACTION_LIST.map((item, index) => (
                           <Link href={item.href} key={index} onClick={closeProfileModal}>
-                            <li className="text-md w-full px-2 py-3 text-left font-medium">{item.label}</li>
+                            <li className="text-md w-full px-2 py-3 text-left font-medium">{t(item.label)}</li>
                           </Link>
                         ))
                       : MOVER_USER_ACTION_LIST.map((item, index) => (
                           <Link href={item.href} key={index} onClick={closeProfileModal}>
-                            <li className="text-md w-full px-2 py-3 text-left font-medium">{item.label}</li>
+                            <li className="text-md w-full px-2 py-3 text-left font-medium">{t(item.label)}</li>
                           </Link>
                         ))}
                   </ul>
@@ -210,7 +215,7 @@ export const GnbActions = ({ userRole, userName, deviceType, toggleSideMenu, isS
                   className="w-full cursor-pointer px-3 py-3 text-xs text-gray-500 transition-colors hover:text-gray-700 lg:text-lg"
                   onClick={() => logout()}
                 >
-                  로그아웃
+                  {t("logout")}
                 </button>
               </div>
             )}
@@ -224,7 +229,7 @@ export const GnbActions = ({ userRole, userName, deviceType, toggleSideMenu, isS
           <button
             onClick={toggleSideMenu}
             className="hover:text-black-400 cursor-pointer p-2 text-gray-400 transition-colors"
-            aria-label="메뉴"
+            aria-label={t("menu")}
           >
             <div className="flex h-6 w-6 flex-col justify-center space-y-1">
               <div

--- a/src/components/notification/NotificationList.tsx
+++ b/src/components/notification/NotificationList.tsx
@@ -8,11 +8,14 @@ import parse from "html-react-parser";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import "dayjs/locale/ko";
+import "dayjs/locale/en";
+import "dayjs/locale/zh";
 import { useRouter } from "next/navigation";
 import { INotification } from "@/types/notification.types";
+import { useTranslations } from "next-intl";
+import { useLocale } from "next-intl";
 
 dayjs.extend(relativeTime);
-dayjs.locale("ko");
 
 export default function NotificationList({ onClose }: { onClose?: () => void }) {
   const notifications = useNotificationStore((state) => state.notifications);
@@ -22,6 +25,11 @@ export default function NotificationList({ onClose }: { onClose?: () => void }) 
   const limit = 4;
   const loadingRef = useRef(false);
   const router = useRouter();
+  const t = useTranslations("notification");
+  const locale = useLocale();
+
+  // dayjs 로케일 설정
+  dayjs.locale(locale);
 
   const { ref, inView } = useInView({ threshold: 0.2 });
 
@@ -52,7 +60,7 @@ export default function NotificationList({ onClose }: { onClose?: () => void }) 
   if (notifications.length === 0) {
     return (
       <div className="flex w-full items-center justify-center">
-        <div className="p-2 text-center text-gray-400">아직 알림이 없어요!</div>
+        <div className="p-2 text-center text-gray-400">{t("noNotifications")}</div>
       </div>
     );
   }
@@ -84,7 +92,7 @@ export default function NotificationList({ onClose }: { onClose?: () => void }) 
         ),
       )}
       {hasMore && <div ref={ref} style={{ height: 40 }} />}
-      {!hasMore && <div className="py-2 text-center text-xs text-gray-400">모든 알림을 불러왔습니다.</div>}
+      {!hasMore && <div className="py-2 text-center text-xs text-gray-400">{t("allNotificationsLoaded")}</div>}
     </div>
   );
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -644,6 +644,25 @@
     "부산": "Busan",
     "제주": "Jeju"
   },
+  "gnb": {
+    "notification": "Notification",
+    "profile": "Profile",
+    "menu": "Menu",
+    "login": "Login",
+    "logout": "Logout",
+    "close": "Close",
+    "defaultUser": "User",
+    "userActions": {
+      "editProfile": "Edit Profile",
+      "favoriteDrivers": "Favorite Drivers",
+      "myReviews": "My Reviews",
+      "myPage": "My Page"
+    },
+    "userSuffix": {
+      "customer": "Customer",
+      "driver": "Driver"
+    }
+  },
   "review": {
     "title": "Review",
     "writableTab": "Writable Reviews",
@@ -671,5 +690,10 @@
     "reviewMinLength": "Please enter at least 10 characters",
     "submitting": "Submitting...",
     "registerReview": "Register Review"
+  },
+  "notification": {
+    "title": "Notifications",
+    "noNotifications": "No notifications yet!",
+    "allNotificationsLoaded": "All notifications loaded."
   }
 }

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -641,6 +641,25 @@
     "부산": "부산",
     "제주": "제주"
   },
+  "gnb": {
+    "notification": "알림",
+    "profile": "프로필",
+    "menu": "메뉴",
+    "login": "로그인",
+    "logout": "로그아웃",
+    "close": "닫기",
+    "defaultUser": "사용자",
+    "userActions": {
+      "editProfile": "프로필 수정",
+      "favoriteDrivers": "찜한 기사님",
+      "myReviews": "이사 리뷰",
+      "myPage": "마이페이지"
+    },
+    "userSuffix": {
+      "customer": "고객님",
+      "driver": "기사님"
+    }
+  },
   "review": {
     "title": "리뷰",
     "writableTab": "작성 가능한 리뷰",
@@ -668,5 +687,10 @@
     "reviewMinLength": "최소 10자 이상 입력해주세요",
     "submitting": "요청 중...",
     "registerReview": "리뷰 등록"
+  },
+  "notification": {
+    "title": "알림",
+    "noNotifications": "아직 알림이 없어요!",
+    "allNotificationsLoaded": "모든 알림을 불러왔습니다."
   }
 }

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -645,6 +645,25 @@
     "부산": "釜山",
     "제주": "济州"
   },
+  "gnb": {
+    "notification": "通知",
+    "profile": "个人资料",
+    "menu": "菜单",
+    "login": "登录",
+    "logout": "登出",
+    "close": "关闭",
+    "defaultUser": "用户",
+    "userActions": {
+      "editProfile": "编辑个人资料",
+      "favoriteDrivers": "收藏的司机",
+      "myReviews": "我的评价",
+      "myPage": "我的页面"
+    },
+    "userSuffix": {
+      "customer": "客户",
+      "driver": "司机"
+    }
+  },
   "review": {
     "title": "评价",
     "writableTab": "可写评价",
@@ -672,5 +691,10 @@
     "reviewMinLength": "请输入至少10个字符",
     "submitting": "提交中...",
     "registerReview": "注册评价"
+  },
+  "notification": {
+    "title": "通知",
+    "noNotifications": "还没有通知！",
+    "allNotificationsLoaded": "已加载所有通知。"
   }
 }


### PR DESCRIPTION
## ✨ 작업 개요
- 알림 관련 파일 다국어 기능 구현 및 비회원 알림 비요청 처리.

## ✅ 주요 작업 내용
- 알림 관련 파일 다국어 기능 구현.
- 알림과 내정도 관련 정보만 사용하는 드롭다운 내의 하드 코딩된 부분 다국어 기능 구현.
- 비회원도 사용할수 있는 페이지에서 헤더를 함께 사용하여 발생한 비회원 알림 요청 문제 해결.

## 🔄 관련 이슈
Closes #202 - 알림 다국어 기능 구현.
Closes #221 - 비회원 알림 요청 문제 해결. 

## 📸 스크린샷 (선택)
<img width="439" height="193" alt="알림 다국어 영어" src="https://github.com/user-attachments/assets/3b2c5925-661e-4470-9478-53644a01040a" />
<img width="443" height="197" alt="알림 다국어 중국어" src="https://github.com/user-attachments/assets/0379b551-edc6-4858-838f-79621763c3d5" />
<img width="424" height="194" alt="알림 다국어" src="https://github.com/user-attachments/assets/ba68ff39-5324-461f-aa47-6105bf3f6272" />


## 🧪 테스트 방법 (선택)
- [ ] 헤더 내에 있는 종모양 클릭시 알림 드롭다운 오픈.
- [ ] 내부의 정적인 데이터만 언어별로 변화 확인.

- [ ] 비회원도 사용 가능한 랜딩, 기사님 찾기 페이지 방문.
- [ ] 네트워크 탭에서 GET Notifications 가 요청되지 않고 그 외의 로그인 페이지에서는 요청되는 것을 확인.

## 📝 비고
