### PR TITLE
[#224] Feat/gnb GNB 및 유저 드롭다운 다국어 작업.

### DIFF
--- a/src/components/common/dropdown/UserActionDropdown.tsx
+++ b/src/components/common/dropdown/UserActionDropdown.tsx
@@ -42,14 +42,14 @@ const DropdownHeader = ({
   showCloseButton?: boolean;
   closeLabel?: string;
 }) => (
-  <div className="inline-flex w-full items-center justify-between bg-white py-3.5 pr-3 pl-4 cursor-default">
+  <div className="inline-flex w-full cursor-default items-center justify-between bg-white py-3.5 pr-3 pl-4">
     <div className="flex items-center justify-start">
       <div className="leading-2lg text-black-400 lg:text-2lg text-left text-base font-bold">{title}</div>
     </div>
     {showCloseButton && onClose && (
       <button
         onClick={onClose}
-        className="flex h-6 w-6 items-center justify-center text-gray-400 transition-colors hover:text-gray-600 cursor-pointer"
+        className="flex h-6 w-6 cursor-pointer items-center justify-center text-gray-400 transition-colors hover:text-gray-600"
         aria-label={closeLabel}
       >
         <IoClose size={20} />
@@ -60,7 +60,7 @@ const DropdownHeader = ({
 
 const UserActionDropdown = ({ type, onClose, isOpen, children, name, triggerRef }: IUserActionDropdownProps) => {
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const t = useTranslations("gnb");
+  const t = useTranslations();
 
   // ESC 키로 닫기
   useEffect(() => {
@@ -108,12 +108,17 @@ const UserActionDropdown = ({ type, onClose, isOpen, children, name, triggerRef 
     <div className="" ref={dropdownRef}>
       {type === "alert" ? (
         <DropdownContainer className="absolute -right-30 w-78 md:-right-7 lg:w-[359px]" rounded="rounded-24">
-          <DropdownHeader title={t("notification")} onClose={onClose} closeLabel={t("close")} />
+          <DropdownHeader title={t("gnb.notification")} onClose={onClose} closeLabel={t("gnb.close")} />
           {children}
         </DropdownContainer>
       ) : (
         <DropdownContainer className="w-38 lg:w-62" rounded="rounded-16">
-          <DropdownHeader title={`${name || t("defaultUser")} ${t("userSuffix.customer")}`} onClose={onClose} showCloseButton={false} closeLabel={t("close")} />
+          <DropdownHeader
+            title={`${name || t("gnb.defaultUser")} ${t("gnb.userSuffix.customer")}`}
+            onClose={onClose}
+            showCloseButton={false}
+            closeLabel={t("gnb.close")}
+          />
           {children}
         </DropdownContainer>
       )}

--- a/src/components/common/gnb/GnbActions.tsx
+++ b/src/components/common/gnb/GnbActions.tsx
@@ -47,7 +47,7 @@ interface IGnbActionsProps {
 
 export const GnbActions = ({ userRole, userName, deviceType, toggleSideMenu, isSideMenuOpen }: IGnbActionsProps) => {
   const { logout } = useAuth();
-  const t = useTranslations("gnb");
+  const t = useTranslations();
 
   const [isNotificationOpen, setIsNotificationOpen] = useState(false);
   const [isProfileOpen, setIsProfileOpen] = useState(false);
@@ -137,7 +137,7 @@ export const GnbActions = ({ userRole, userName, deviceType, toggleSideMenu, isS
           href="/userSignin"
           className="bg-primary-400 hover:bg-primary-500 rounded-md px-4 py-2 text-sm font-medium text-white transition-colors"
         >
-          {t("login")}
+          {t("auth.signin")}
         </Link>
       )}
 
@@ -146,16 +146,16 @@ export const GnbActions = ({ userRole, userName, deviceType, toggleSideMenu, isS
           {/* 알림 버튼 */}
           <div
             className="hover:text-black-400 cursor-pointer p-2 text-gray-400 transition-colors"
-            aria-label={t("notification")}
+            aria-label={t("gnb.notification")}
           >
             <div className="relative h-6 w-6">
               <button
                 ref={notificationButtonRef}
                 onClick={handleNotificationClick}
                 className="cursor-pointer"
-                aria-label={t("notification")}
+                aria-label={t("gnb.notification")}
               >
-                <Image src={notification} alt={t("notification")} width={24} height={24} />
+                <Image src={notification} alt={t("gnb.notification")} width={24} height={24} />
                 {hasUnread && <div className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-red-500"></div>}
               </button>
               <UserActionDropdown
@@ -164,7 +164,7 @@ export const GnbActions = ({ userRole, userName, deviceType, toggleSideMenu, isS
                 isOpen={isNotificationOpen}
                 triggerRef={notificationButtonRef}
               >
-                <NotificationList onClose={() => setIsNotificationOpen(false)} />
+                <NotificationList />
               </UserActionDropdown>
             </div>
           </div>
@@ -175,9 +175,9 @@ export const GnbActions = ({ userRole, userName, deviceType, toggleSideMenu, isS
               ref={profileButtonRef}
               onClick={handleProfileClick}
               className="flex cursor-pointer gap-3 p-2 text-black"
-              aria-label={t("profile")}
+              aria-label={t("gnb.profile")}
             >
-              <Image src={profile} alt={t("profile")} width={24} height={24} />
+              <Image src={profile} alt={t("gnb.profile")} width={24} height={24} />
               <div className="hidden lg:block">{userName}</div>
             </button>
 
@@ -189,7 +189,7 @@ export const GnbActions = ({ userRole, userName, deviceType, toggleSideMenu, isS
               >
                 <nav className="flex flex-col items-start justify-start border-b border-[#F2F2F2]">
                   <span className="w-full px-2 py-2 text-left text-lg">
-                    {userName} {userRole === "CUSTOMER" ? t("userSuffix.customer") : t("userSuffix.driver")}
+                    {userName} {userRole === "CUSTOMER" ? t("gnb.userSuffix.customer") : t("gnb.userSuffix.driver")}
                   </span>
                   <ul className="flex w-full flex-col">
                     {userRole === "CUSTOMER"
@@ -209,7 +209,7 @@ export const GnbActions = ({ userRole, userName, deviceType, toggleSideMenu, isS
                   className="w-full cursor-pointer px-3 py-3 text-xs text-gray-500 transition-colors hover:text-gray-700 lg:text-lg"
                   onClick={() => logout()}
                 >
-                  {t("logout")}
+                  {t("gnb.logout")}
                 </button>
               </div>
             )}
@@ -223,7 +223,7 @@ export const GnbActions = ({ userRole, userName, deviceType, toggleSideMenu, isS
           <button
             onClick={toggleSideMenu}
             className="hover:text-black-400 cursor-pointer p-2 text-gray-400 transition-colors"
-            aria-label={t("menu")}
+            aria-label={t("gnb.menu")}
           >
             <div className="flex h-6 w-6 flex-col justify-center space-y-1">
               <div


### PR DESCRIPTION
## ✨ 작업 개요
- GNB 및 유저 드롭다운 다국어 작업.

## ✅ 주요 작업 내용
- GNB 다국어 코드 수정.
- 유저 드롭다운 다국어 코드 수정.

## 🔄 관련 이슈
Closes #224 - GNB 및 유저 드롭다운 다국어 작업.

## 📸 스크린샷 (선택)
<img width="337" height="319" alt="image" src="https://github.com/user-attachments/assets/e129ca83-7f35-447a-912e-fd457e2cb6c9" />
<img width="333" height="294" alt="image" src="https://github.com/user-attachments/assets/0a091d82-1220-43c4-99fb-7d682dc277a8" />
<img width="315" height="304" alt="image" src="https://github.com/user-attachments/assets/dd8b53c8-695e-40f5-9ab0-723991129af0" />


## 🧪 테스트 방법 (선택)
- [ ] 헤더 내에 있는 프로필 부분 클릭시 유저 드롭다운 오픈.
- [ ] 내부의 정적인 데이터만 언어별로 변화 확인.

## 📝 비고
