### PR TITLE
feat:기본정보 수정 모달 구현

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -484,7 +484,10 @@
 
     "forgotPassword": "Forgot your password?",
     "snsLogin": "Login easily with your SNS account",
-    "confirm": "Confirm"
+    "confirm": "Confirm",
+    "successTitle": "Profile Update Complete",
+    "errorTitle": "Update Failed",
+    "generalErrorTitle": "Error Occurred"
   },
   "landing": {
     "title": "How do you choose a moving company?",

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -480,7 +480,10 @@
 
     "forgotPassword": "비밀번호를 잊으셨나요?",
     "snsLogin": "SNS 계정으로 간편 로그인",
-    "confirm": "확인"
+    "confirm": "확인",
+    "successTitle": "기본정보 수정 완료",
+    "errorTitle": "수정 실패",
+    "generalErrorTitle": "오류 발생"
   },
   "landing": {
     "title": "이사업체, 어떻게 고르세요?",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -485,7 +485,10 @@
 
     "forgotPassword": "忘记密码？",
     "snsLogin": "使用SNS账户轻松登录",
-    "confirm": "确认"
+    "confirm": "确认",
+    "successTitle": "个人资料更新完成",
+    "errorTitle": "更新失败",
+    "generalErrorTitle": "发生错误"
   },
   "landing": {
     "title": "如何选择搬家公司？",

--- a/src/pageComponents/moverMyPage/edit/EditPage.tsx
+++ b/src/pageComponents/moverMyPage/edit/EditPage.tsx
@@ -11,12 +11,15 @@ import { useRouter } from "next/navigation";
 import userApi from "@/lib/api/user.api";
 import { useAuth } from "@/providers/AuthProvider";
 import { useValidationRules } from "@/hooks/useValidationRules";
+import { useModal } from "@/components/common/modal/ModalContext";
 
 const EditPage = () => {
   const router = useRouter();
   const { getUser } = useAuth();
+  const { open, close } = useModal();
   const [formError, setFormError] = useState<string | null>(null);
   const t = useTranslations("edit");
+  const authT = useTranslations("auth");
   const locale = useLocale();
   const validationRules = useValidationRules();
   const form = useForm<IEditBasicForm>({
@@ -78,17 +81,36 @@ const EditPage = () => {
       const result = await userApi.updateMoverBasicInfo(req);
       if (result.success) {
         await getUser();
-        alert(t("successMessage"));
-        router.push(`/${locale}/moverMyPage`);
+        open({
+          title: authT("successTitle"),
+          children: <div>{t("successMessage")}</div>,
+          buttons: [
+            {
+              text: authT("confirm"),
+              onClick: () => {
+                close();
+                router.push(`/${locale}/moverMyPage`);
+              },
+            },
+          ],
+        });
       } else {
         if (result.message?.includes("비밀번호")) {
           form.setError("currentPassword", { message: result.message });
         } else {
-          setFormError(result.message || t("errorMessage"));
+          open({
+            title: authT("errorTitle"),
+            children: <div>{result.message || t("errorMessage")}</div>,
+            buttons: [{ text: authT("confirm"), onClick: () => close() }],
+          });
         }
       }
     } catch (e) {
-      setFormError(t("generalError"));
+      open({
+        title: authT("generalErrorTitle"),
+        children: <div>{t("generalError")}</div>,
+        buttons: [{ text: authT("confirm"), onClick: () => close() }],
+      });
     }
   };
 


### PR DESCRIPTION
## ✨ 작업 개요
- 기사님 기본정보 수정 페이지에서 alert 대신 모달을 사용하도록 변경
- 모달에 다국어 기능 추가

## ✅ 주요 작업 내용
- EditPage.tsx 컴포넌트에 useModal 훅 추가
- alert() 호출을 open() 모달 호출로 변경
- 다국어 파일(ko.json, en.json, zh.json)에 모달 관련 키 추가

## 🔄 관련 이슈
Closes #72 

## 📸 스크린샷 (선택)
<img width="1346" height="728" alt="스크린샷 2025-07-30 오전 12 27 34" src="https://github.com/user-attachments/assets/dbc5e839-d5a0-4996-8279-9c7260ad5500" />
<img width="1346" height="728" alt="스크린샷 2025-07-30 오전 12 27 48" src="https://github.com/user-attachments/assets/a965a2e2-86cf-4345-955a-85a3b7abc57c" />
<img width="1346" height="728" alt="스크린샷 2025-07-30 오전 12 28 01" src="https://github.com/user-attachments/assets/6420c192-d6a4-4077-b056-0d7b53b2d154" />

## 🧪 테스트 방법 (선택)
- [ ] 이름, 전화번호 수정 후 저장
- [ ] 성공 시 "기본정보 수정 완료" 모달 표시 확인

## 📝 비고
- (버그, 추후 개선사항 등)