### PR TITLE
[#247] feat : 간편 로그인 전환 기능 구현 및 사이드바 오류 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "dayjs": "^1.11.13",
         "dompurify": "^3.2.6",
         "event-source-polyfill": "^1.0.31",
+        "framer-motion": "^12.23.12",
         "html-react-parser": "^5.2.6",
         "jose": "^6.0.11",
         "lodash.throttle": "^4.1.1",
@@ -28,6 +29,7 @@
         "react-icons": "^5.5.0",
         "react-intersection-observer": "^9.16.0",
         "react-simple-star-rating": "^5.1.7",
+        "react-toastify": "^11.0.5",
         "sharp": "^0.34.3",
         "zustand": "^5.0.6"
       },
@@ -8073,6 +8075,32 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.12.tgz",
+      "integrity": "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==",
+      "dependencies": {
+        "motion-dom": "^12.23.12",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -11097,6 +11125,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/motion-dom": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ=="
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -12122,7 +12163,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
       "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
-      "license": "MIT",
       "peerDependencies": {
         "react": "*"
       }
@@ -12165,6 +12205,18 @@
       "peerDependencies": {
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/redent": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dayjs": "^1.11.13",
     "dompurify": "^3.2.6",
     "event-source-polyfill": "^1.0.31",
+    "framer-motion": "^12.23.12",
     "html-react-parser": "^5.2.6",
     "jose": "^6.0.11",
     "lodash.throttle": "^4.1.1",
@@ -30,6 +31,7 @@
     "react-icons": "^5.5.0",
     "react-intersection-observer": "^9.16.0",
     "react-simple-star-rating": "^5.1.7",
+    "react-toastify": "^11.0.5",
     "sharp": "^0.34.3",
     "zustand": "^5.0.6"
   },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import Script from "next/script";
 import { routing } from "@/i18n/routing";
 import { NextIntlClientProvider, hasLocale } from "next-intl";
 import LanguageSync from "./[locale]/LanguageSync";
+import { ToastContainer } from "react-toastify";
 
 const pretendard = localFont({
   src: "../assets/font/PretendardVariable.woff2",
@@ -73,6 +74,14 @@ export default async function LocaleLayout({
             <Gnb />
             {children}
             {/* <DevNavitgation /> */}
+            <ToastContainer
+              position="top-center"
+              autoClose={2000}
+              hideProgressBar
+              pauseOnHover={false}
+              draggable={false}
+              closeOnClick
+            />
           </Providers>
         </NextIntlClientProvider>
       </body>

--- a/src/components/common/gnb/Gnb.tsx
+++ b/src/components/common/gnb/Gnb.tsx
@@ -16,6 +16,7 @@ export const Gnb = () => {
   const userRole = user?.userType || "GUEST";
   const userName = user?.nickname || user?.name || "";
   const userProfileImage = userRole === "CUSTOMER" ? user?.customerImage : user?.moverImage;
+  const hasBothProfiles = user?.hasBothProfiles || false;
 
   const toggleMobileMenu = () => {
     setIsMobileMenuOpen(!isMobileMenuOpen);
@@ -38,6 +39,7 @@ export const Gnb = () => {
                 logout={logout}
                 userName={userName}
                 deviceType={deviceType}
+                hasBothProfiles={hasBothProfiles}
                 toggleSideMenu={toggleMobileMenu}
                 isSideMenuOpen={isMobileMenuOpen}
                 profileImage={userProfileImage}
@@ -52,6 +54,7 @@ export const Gnb = () => {
                 logout={logout}
                 userName={userName}
                 deviceType={deviceType}
+                hasBothProfiles={hasBothProfiles}
                 toggleSideMenu={toggleMobileMenu}
                 isSideMenuOpen={isMobileMenuOpen}
                 profileImage={userProfileImage}

--- a/src/components/common/gnb/GnbActions.tsx
+++ b/src/components/common/gnb/GnbActions.tsx
@@ -12,34 +12,14 @@ import NotificationList from "@/components/notification/NotificationList";
 import UserActionDropdown from "../dropdown/UserActionDropdown";
 import { useNotificationStore } from "@/stores/notificationStore";
 import { useTranslations } from "next-intl";
-
-const USER_ACTION_LIST = [
-  {
-    label: "gnb.userActions.editProfile",
-    href: "/profile/edit",
-  },
-  {
-    label: "gnb.userActions.favoriteDrivers",
-    href: "/user/favorite",
-  },
-];
-
-const MOVER_USER_ACTION_LIST = [
-  {
-    label: "gnb.userActions.editProfile",
-    href: "/profile/edit",
-  },
-  {
-    label: "gnb.userActions.myPage",
-    href: "/moverMyPage",
-  },
-];
+import ProfileModal from "./ProfileModal";
 
 interface IGnbActionsProps {
   userRole: TUserRole;
   userName: string;
   deviceType: TDeviceType;
   isSideMenuOpen: boolean;
+  hasBothProfiles: boolean;
   profileImage?: string;
   logout: () => void;
   toggleSideMenu: () => void;
@@ -49,6 +29,7 @@ export const GnbActions = ({
   userRole,
   logout,
   userName,
+  hasBothProfiles,
   deviceType,
   toggleSideMenu,
   isSideMenuOpen,
@@ -205,35 +186,14 @@ export const GnbActions = ({
 
             {/* 프로필 모달창 */}
             {isProfileOpen && (
-              <div
-                ref={profileModalRef}
-                className="absolute top-full right-0 z-50 mt-2 w-[180px] rounded-2xl border-2 border-[#F2F2F2] bg-white px-2 py-2.5 font-bold shadow-lg lg:w-[248px]"
-              >
-                <nav className="flex flex-col items-start justify-start border-b border-[#F2F2F2]">
-                  <span className="w-full px-2 py-2 text-left text-lg">
-                    {userName} {userRole === "CUSTOMER" ? t("gnb.userSuffix.customer") : t("gnb.userSuffix.driver")}
-                  </span>
-                  <ul className="flex w-full flex-col">
-                    {userRole === "CUSTOMER"
-                      ? USER_ACTION_LIST.map((item, index) => (
-                          <Link href={item.href} key={index} onClick={closeProfileModal}>
-                            <li className="text-md w-full px-2 py-3 text-left font-medium">{t(item.label)}</li>
-                          </Link>
-                        ))
-                      : MOVER_USER_ACTION_LIST.map((item, index) => (
-                          <Link href={item.href} key={index} onClick={closeProfileModal}>
-                            <li className="text-md w-full px-2 py-3 text-left font-medium">{t(item.label)}</li>
-                          </Link>
-                        ))}
-                  </ul>
-                </nav>
-                <button
-                  className="w-full cursor-pointer px-3 py-3 text-xs text-gray-500 transition-colors hover:text-gray-700 lg:text-lg"
-                  onClick={() => logout()}
-                >
-                  {t("gnb.logout")}
-                </button>
-              </div>
+              <ProfileModal
+                userName={userName}
+                userRole={userRole}
+                hasBothProfiles={hasBothProfiles}
+                logout={logout}
+                profileModalRef={profileModalRef}
+                closeProfileModal={closeProfileModal}
+              />
             )}
           </div>
         </>

--- a/src/components/common/gnb/ProfileModal.tsx
+++ b/src/components/common/gnb/ProfileModal.tsx
@@ -73,7 +73,7 @@ function ProfileModal({
           <div
             className={`relative flex w-full items-center justify-between ${!hasBothProfiles ? "cursor-not-allowed opacity-50" : ""}`}
           >
-            <span className="text-md font-medium">간편 전환</span>
+            <span className="text-md font-medium">{t("gnb.roleToggleText")}</span>
             <RoleToggle disabled={!hasBothProfiles} />
           </div>
           {!hasBothProfiles && (

--- a/src/components/common/gnb/ProfileModal.tsx
+++ b/src/components/common/gnb/ProfileModal.tsx
@@ -76,7 +76,7 @@ function ProfileModal({
             <span className="text-md font-medium">간편 전환</span>
             <RoleToggle disabled={!hasBothProfiles} />
           </div>
-          {/* {!hasBothProfiles && (
+          {!hasBothProfiles && (
             <>
               <FaLock className="ml-1 text-gray-400" size={14} aria-label="Locked" />
               <div className="absolute -top-12 left-1/2 z-10 hidden w-[220px] -translate-x-1/2 rounded bg-gray-800 px-3 py-2 text-xs text-white group-hover:block">
@@ -84,7 +84,7 @@ function ProfileModal({
                 <div className="absolute top-full left-1/2 h-2 w-2 -translate-x-1/2 rotate-45 bg-gray-800" />
               </div>
             </>
-          )} */}
+          )}
         </div>
 
         <button

--- a/src/components/common/gnb/ProfileModal.tsx
+++ b/src/components/common/gnb/ProfileModal.tsx
@@ -68,12 +68,15 @@ function ProfileModal({
               ))}
         </ul>
       </nav>
-      <div className="flex flex-col items-center justify-between">
-        <div className="group relative flex items-center gap-2 py-3">
-          <div className={`relative ${!hasBothProfiles ? "cursor-not-allowed opacity-50" : ""}`}>
+      <div className="flex flex-col items-center justify-between gap-2">
+        <div className="group relative flex w-full items-center justify-between gap-2 px-2 py-3">
+          <div
+            className={`relative flex w-full items-center justify-between ${!hasBothProfiles ? "cursor-not-allowed opacity-50" : ""}`}
+          >
+            <span className="text-md font-medium">간편 전환</span>
             <RoleToggle disabled={!hasBothProfiles} />
           </div>
-          {!hasBothProfiles && (
+          {/* {!hasBothProfiles && (
             <>
               <FaLock className="ml-1 text-gray-400" size={14} aria-label="Locked" />
               <div className="absolute -top-12 left-1/2 z-10 hidden w-[220px] -translate-x-1/2 rounded bg-gray-800 px-3 py-2 text-xs text-white group-hover:block">
@@ -81,7 +84,7 @@ function ProfileModal({
                 <div className="absolute top-full left-1/2 h-2 w-2 -translate-x-1/2 rotate-45 bg-gray-800" />
               </div>
             </>
-          )}
+          )} */}
         </div>
 
         <button

--- a/src/components/common/gnb/ProfileModal.tsx
+++ b/src/components/common/gnb/ProfileModal.tsx
@@ -1,0 +1,98 @@
+import { Link } from "@/i18n/navigation";
+import { TUserRole } from "@/types/user.types";
+import { useTranslations } from "next-intl";
+import { RoleToggle } from "./RoleToggle";
+import { FaLock } from "react-icons/fa";
+
+interface IProfileModalProps {
+  userName: string;
+  userRole: TUserRole;
+  hasBothProfiles: boolean;
+  logout: () => void;
+  profileModalRef: React.RefObject<HTMLDivElement | null>;
+  closeProfileModal: () => void;
+}
+
+const USER_ACTION_LIST = [
+  {
+    label: "gnb.userActions.editProfile",
+    href: "/profile/edit",
+  },
+  {
+    label: "gnb.userActions.favoriteDrivers",
+    href: "/user/favorite",
+  },
+];
+
+const MOVER_USER_ACTION_LIST = [
+  {
+    label: "gnb.userActions.editProfile",
+    href: "/profile/edit",
+  },
+  {
+    label: "gnb.userActions.myPage",
+    href: "/moverMyPage",
+  },
+];
+
+function ProfileModal({
+  userName,
+  userRole,
+  hasBothProfiles,
+  logout,
+  profileModalRef,
+  closeProfileModal,
+}: IProfileModalProps) {
+  const t = useTranslations();
+
+  return (
+    <div
+      ref={profileModalRef}
+      className="absolute top-full right-[-50px] z-50 mt-2 w-[205px] rounded-2xl border-2 border-[#F2F2F2] bg-white px-2 py-2.5 font-bold shadow-lg lg:right-0 lg:w-[248px]"
+    >
+      <nav className="flex flex-col items-start justify-start border-b border-[#F2F2F2]">
+        <span className="w-full px-2 py-2 text-left text-lg">
+          {userName} {userRole === "CUSTOMER" ? t("gnb.userSuffix.customer") : t("gnb.userSuffix.driver")}
+        </span>
+        <ul className="flex w-full flex-col">
+          {userRole === "CUSTOMER"
+            ? USER_ACTION_LIST.map((item, index) => (
+                <Link href={item.href} key={index} onClick={closeProfileModal}>
+                  <li className="text-md w-full px-2 py-3 text-left font-medium">{t(item.label)}</li>
+                </Link>
+              ))
+            : MOVER_USER_ACTION_LIST.map((item, index) => (
+                <Link href={item.href} key={index} onClick={closeProfileModal}>
+                  <li className="text-md w-full px-2 py-3 text-left font-medium">{t(item.label)}</li>
+                </Link>
+              ))}
+        </ul>
+      </nav>
+      <div className="flex flex-col items-center justify-between">
+        <div className="group relative flex items-center gap-2 py-3">
+          <div className={`relative ${!hasBothProfiles ? "cursor-not-allowed opacity-50" : ""}`}>
+            <RoleToggle disabled={!hasBothProfiles} />
+          </div>
+          {!hasBothProfiles && (
+            <>
+              <FaLock className="ml-1 text-gray-400" size={14} aria-label="Locked" />
+              <div className="absolute -top-12 left-1/2 z-10 hidden w-[220px] -translate-x-1/2 rounded bg-gray-800 px-3 py-2 text-xs text-white group-hover:block">
+                {t("gnb.roleToggleLockMessage")}
+                <div className="absolute top-full left-1/2 h-2 w-2 -translate-x-1/2 rotate-45 bg-gray-800" />
+              </div>
+            </>
+          )}
+        </div>
+
+        <button
+          className="w-full cursor-pointer px-3 py-3 text-xs text-gray-500 transition-colors hover:text-gray-700 lg:text-lg"
+          onClick={() => logout()}
+        >
+          {t("gnb.logout")}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default ProfileModal;

--- a/src/components/common/gnb/RoleToggle.tsx
+++ b/src/components/common/gnb/RoleToggle.tsx
@@ -1,8 +1,8 @@
 import { useSwitchUserType } from "@/hooks/useSwitchUserType";
+import { useWindowWidth } from "@/hooks/useWindowWidth";
 import { useAuth } from "@/providers/AuthProvider";
 import { motion } from "framer-motion";
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 interface IRoleToggleProps {
   disabled?: boolean;
 }
@@ -11,7 +11,6 @@ export const RoleToggle = ({ disabled = false }: IRoleToggleProps) => {
   const { user } = useAuth();
   const { mutate, isPending } = useSwitchUserType();
   const [fakeUserType, setFakeUserType] = useState<"CUSTOMER" | "MOVER" | null>(null);
-  const router = useRouter();
   const handleToggle = () => {
     if (!user || disabled) return;
     const current = user.userType;
@@ -22,26 +21,47 @@ export const RoleToggle = ({ disabled = false }: IRoleToggleProps) => {
 
   const typeToShow = fakeUserType ?? user?.userType;
 
+  const windowWidth = useWindowWidth();
+
+  useEffect(() => {
+    console.log(windowWidth);
+  }, [windowWidth]);
+
   return (
     <button
       onClick={handleToggle}
       disabled={isPending || disabled}
-      className={`relative flex h-8 w-20 cursor-pointer items-center rounded-full p-1 transition-colors ${
-        typeToShow === "MOVER" ? "bg-black" : "bg-orange-500"
+      className={`relative flex h-8 w-20 cursor-pointer items-center rounded-full p-1 transition-colors lg:w-30 ${
+        typeToShow === "MOVER" ? "bg-gray-600" : "bg-primary-400"
       }`}
     >
-      <motion.div
-        className="flex h-6 w-6 items-center justify-center rounded-full bg-white text-sm"
-        animate={{ x: typeToShow === "MOVER" ? 48 : 0 }}
-        initial={false}
-        transition={{
-          type: "spring",
-          stiffness: 500,
-          damping: 30,
-        }}
-      >
-        {typeToShow === "MOVER" ? "🚚" : "👤"}
-      </motion.div>
+      {windowWidth === "desktop" ? (
+        <motion.div
+          className="flex h-6 w-6 items-center justify-center rounded-full bg-white text-sm"
+          animate={{ x: typeToShow === "MOVER" ? 88 : 0 }}
+          initial={false}
+          transition={{
+            type: "spring",
+            stiffness: 500,
+            damping: 30,
+          }}
+        >
+          {typeToShow === "MOVER" ? "🚚" : "👤"}
+        </motion.div>
+      ) : (
+        <motion.div
+          className="flex h-6 w-6 items-center justify-center rounded-full bg-white text-sm"
+          animate={{ x: typeToShow === "MOVER" ? 48 : 0 }}
+          initial={false}
+          transition={{
+            type: "spring",
+            stiffness: 500,
+            damping: 30,
+          }}
+        >
+          {typeToShow === "MOVER" ? "🚚" : "👤"}
+        </motion.div>
+      )}
     </button>
   );
 };

--- a/src/components/common/gnb/RoleToggle.tsx
+++ b/src/components/common/gnb/RoleToggle.tsx
@@ -1,0 +1,47 @@
+import { useSwitchUserType } from "@/hooks/useSwitchUserType";
+import { useAuth } from "@/providers/AuthProvider";
+import { motion } from "framer-motion";
+import { useState } from "react";
+
+interface IRoleToggleProps {
+  disabled?: boolean;
+}
+
+export const RoleToggle = ({ disabled = false }: IRoleToggleProps) => {
+  const { user } = useAuth();
+  const { mutate, isPending } = useSwitchUserType();
+  const [fakeUserType, setFakeUserType] = useState<"CUSTOMER" | "MOVER" | null>(null);
+
+  const handleToggle = () => {
+    if (!user || disabled) return;
+    const current = user.userType;
+    const target = current === "CUSTOMER" ? "MOVER" : "CUSTOMER";
+    setFakeUserType(target);
+    setTimeout(() => mutate(), 300);
+  };
+
+  const typeToShow = fakeUserType ?? user?.userType;
+
+  return (
+    <button
+      onClick={handleToggle}
+      disabled={isPending || disabled}
+      className={`relative flex h-8 w-20 cursor-pointer items-center rounded-full p-1 transition-colors ${
+        typeToShow === "MOVER" ? "bg-black" : "bg-orange-500"
+      }`}
+    >
+      <motion.div
+        className="flex h-6 w-6 items-center justify-center rounded-full bg-white text-sm"
+        animate={{ x: typeToShow === "MOVER" ? 48 : 0 }}
+        initial={false}
+        transition={{
+          type: "spring",
+          stiffness: 500,
+          damping: 30,
+        }}
+      >
+        {typeToShow === "MOVER" ? "🚚" : "👤"}
+      </motion.div>
+    </button>
+  );
+};

--- a/src/components/common/gnb/RoleToggle.tsx
+++ b/src/components/common/gnb/RoleToggle.tsx
@@ -2,7 +2,7 @@ import { useSwitchUserType } from "@/hooks/useSwitchUserType";
 import { useAuth } from "@/providers/AuthProvider";
 import { motion } from "framer-motion";
 import { useState } from "react";
-
+import { useRouter } from "next/navigation";
 interface IRoleToggleProps {
   disabled?: boolean;
 }
@@ -11,7 +11,7 @@ export const RoleToggle = ({ disabled = false }: IRoleToggleProps) => {
   const { user } = useAuth();
   const { mutate, isPending } = useSwitchUserType();
   const [fakeUserType, setFakeUserType] = useState<"CUSTOMER" | "MOVER" | null>(null);
-
+  const router = useRouter();
   const handleToggle = () => {
     if (!user || disabled) return;
     const current = user.userType;

--- a/src/components/common/gnb/SideGnb.tsx
+++ b/src/components/common/gnb/SideGnb.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 import { TUserRole } from "@/types/user.types";
 import { GEUST_NAVIGATION_ITEMS, CUSTOMER_NAVIGATION_ITEMS, MOVER_NAVIGATION_ITEMS } from "@/constant/gnbItems";
 import { useTranslations } from "next-intl";
+import { getPathWithoutLocale } from "@/utils/locale";
 
 interface ISideGnbProps {
   isOpen: boolean;
@@ -17,8 +18,8 @@ interface ISideGnbProps {
 export const SideGnb = ({ isOpen, onClose, userRole = "GUEST" }: ISideGnbProps) => {
   const pathname = usePathname();
   const t = useTranslations();
+  const cleanPath = getPathWithoutLocale(pathname); // "/ko/mypage" -> "/mypage"
 
-  // 로그인 상태에 따른 메뉴 결정
   const getMenuItems = () => {
     if (userRole === "GUEST") {
       return [...GEUST_NAVIGATION_ITEMS, { name: "auth.signin", href: "/userSignin" }];
@@ -29,48 +30,48 @@ export const SideGnb = ({ isOpen, onClose, userRole = "GUEST" }: ISideGnbProps) 
 
   const menuItems = getMenuItems();
 
-  // 오버레이 클릭 시 닫기
-  const handleOverlayClick = (e: React.MouseEvent) => {
-    if (e.target === e.currentTarget) {
-      onClose();
-    }
+  const isActive = (href: string) => {
+    return (
+      cleanPath === href ||
+      cleanPath.startsWith(href + "/") ||
+      (href === "/review/writable" && (cleanPath === "/review/writable" || cleanPath === "/review/written")) ||
+      (href === "/estimateRequest/pending" &&
+        (cleanPath === "/estimateRequest/pending" || cleanPath === "/estimateRequest/received")) ||
+      ["/ko", "/en", "/zh"].includes(cleanPath)
+    );
   };
 
   return (
     <>
-      {/* 오버레이 */}
       <div
         className={`fixed inset-0 z-40 bg-black/50 transition-opacity duration-300 ease-in-out lg:hidden ${
           isOpen ? "opacity-100" : "pointer-events-none opacity-0"
         }`}
-        onClick={handleOverlayClick}
+        onClick={(e) => e.target === e.currentTarget && onClose()}
         aria-hidden="true"
       />
 
-      {/* 사이드바 */}
       <div
         className={`fixed top-0 right-0 z-50 h-full w-80 transform bg-white shadow-xl transition-transform duration-300 ease-in-out lg:hidden ${
           isOpen ? "translate-x-0" : "translate-x-full"
         }`}
       >
-        {/* 헤더 */}
+        {/* 닫기 버튼 */}
         <div className="flex justify-end border-b border-gray-200">
           <button
             onClick={onClose}
             className="hover:text-black-400 cursor-pointer p-2 px-6 py-4.5 text-gray-400 transition-colors"
             aria-label="메뉴 닫기"
           >
-            {/* X 아이콘 */}
             <div className="relative h-6 w-6">
-              <div className="absolute top-1/2 left-1/2 h-0.5 w-4 -translate-x-1/2 -translate-y-1/2 rotate-45 bg-current"></div>
-              <div className="absolute top-1/2 left-1/2 h-0.5 w-4 -translate-x-1/2 -translate-y-1/2 -rotate-45 bg-current"></div>
+              <div className="absolute top-1/2 left-1/2 h-0.5 w-4 -translate-x-1/2 -translate-y-1/2 rotate-45 bg-current" />
+              <div className="absolute top-1/2 left-1/2 h-0.5 w-4 -translate-x-1/2 -translate-y-1/2 -rotate-45 bg-current" />
             </div>
           </button>
         </div>
 
-        {/* 메뉴 내용 */}
+        {/* 메뉴 리스트 */}
         <div className="flex h-full flex-col">
-          {/* 네비게이션 메뉴 */}
           <nav>
             {menuItems.map((item) => (
               <Link
@@ -78,7 +79,7 @@ export const SideGnb = ({ isOpen, onClose, userRole = "GUEST" }: ISideGnbProps) 
                 href={item.href}
                 onClick={onClose}
                 className={`block rounded-lg px-5 py-6 text-lg font-medium transition-colors hover:bg-gray-100 ${
-                  pathname === item.href || pathname === "/" ? "text-black" : "text-gray-400"
+                  isActive(item.href) ? "text-black" : "text-gray-400"
                 }`}
               >
                 {t(item.name)}

--- a/src/hooks/useSwitchUserType.tsx
+++ b/src/hooks/useSwitchUserType.tsx
@@ -1,0 +1,35 @@
+// hooks/useSwitchUserType.ts
+import { useMutation } from "@tanstack/react-query";
+import { useAuth } from "@/providers/AuthProvider";
+import authApi from "@/lib/api/auth.api";
+import { toast } from "react-toastify";
+import { useRouter } from "next/navigation";
+
+export const useSwitchUserType = () => {
+  const router = useRouter();
+  const { user, getUser } = useAuth();
+
+  return useMutation({
+    mutationFn: async () => {
+      const targetType = user?.userType === "CUSTOMER" ? "MOVER" : "CUSTOMER";
+      const res = await authApi.switchUserType(targetType);
+      return res;
+    },
+    onSuccess: async (res) => {
+      // 토스트 메시지
+      toast.success(`${res.newUserType === "CUSTOMER" ? "일반 유저" : "기사님"}(으)로 전환되었습니다`);
+
+      // 유저 정보 다시 불러오기
+      await getUser();
+
+      if (res?.newUserType === "CUSTOMER") {
+        router.replace("/searchMover");
+      } else {
+        router.replace("/estimate/received");
+      }
+    },
+    onError: (err: any) => {
+      toast.error(err?.message || "전환에 실패했습니다");
+    },
+  });
+};

--- a/src/lib/api/auth.api.ts
+++ b/src/lib/api/auth.api.ts
@@ -64,6 +64,28 @@ const authApi = {
     return responseData;
   },
 
+  // 유저 타입 변경
+  switchUserType: async (userType: "CUSTOMER" | "MOVER") => {
+    console.log("userType", userType);
+
+    const response = await fetch(`${API_URL}/auth/switch-role`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${await getAccessToken()}`,
+      },
+      body: JSON.stringify({ userType }),
+    });
+
+    const responseData = await response.json();
+
+    if (responseData.success) {
+      setTokensToCookie(responseData.accessToken);
+    }
+
+    return responseData;
+  },
+
   // 리프레쉬 토큰을 사용한 토큰 갱신
   refreshToken: async () => {
     const response = await fetch(`${API_URL}/auth/refresh-token`, {

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -733,7 +733,8 @@
       "customer": "Customer",
       "driver": "Driver"
     },
-    "roleToggleLockMessage": "You need to complete profile registration for both roles (Customer and Mover) to switch roles easily!"
+    "roleToggleLockMessage": "You need to complete profile registration for both roles (Customer and Mover) to switch roles easily!",
+    "roleToggleText": "Quick Switch"
   },
   "review": {
     "title": "Review",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -732,7 +732,8 @@
     "userSuffix": {
       "customer": "Customer",
       "driver": "Driver"
-    }
+    },
+    "roleToggleLockMessage": "You need to complete profile registration for both roles (Customer and Mover) to switch roles easily!"
   },
   "review": {
     "title": "Review",

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -721,7 +721,8 @@
       "customer": "고객님",
       "driver": "기사님"
     },
-    "roleToggleLockMessage": "두 역할(일반회원, 기사님) 모두 프로필 등록을 완료해야 간편 전환이 가능합니다!"
+    "roleToggleLockMessage": "두 역할(일반회원, 기사님) 모두 프로필 등록을 완료해야 간편 전환이 가능합니다!",
+    "roleToggleText": "간편 전환"
   },
   "review": {
     "title": "리뷰",

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -720,7 +720,8 @@
     "userSuffix": {
       "customer": "고객님",
       "driver": "기사님"
-    }
+    },
+    "roleToggleLockMessage": "두 역할(일반회원, 기사님) 모두 프로필 등록을 완료해야 간편 전환이 가능합니다!"
   },
   "review": {
     "title": "리뷰",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -733,7 +733,8 @@
     "userSuffix": {
       "customer": "客户",
       "driver": "司机"
-    }
+    },
+    "roleToggleLockMessage": "需完成两个身份（一般会员与搬家师傅）的资料注册，方可快速切换角色！"
   },
   "review": {
     "title": "评价",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -734,7 +734,8 @@
       "customer": "客户",
       "driver": "司机"
     },
-    "roleToggleLockMessage": "需完成两个身份（一般会员与搬家师傅）的资料注册，方可快速切换角色！"
+    "roleToggleLockMessage": "需完成两个身份（一般会员与搬家师傅）的资料注册，方可快速切换角色！",
+    "roleToggleText": "快速切换"
   },
   "review": {
     "title": "评价",

--- a/src/pageComponents/profile/edit/CustomerEditPage.tsx
+++ b/src/pageComponents/profile/edit/CustomerEditPage.tsx
@@ -139,10 +139,6 @@ export default function CustomerEditPage() {
     fetchProfile();
   }, [reset]);
 
-  useEffect(() => {
-    console.log(validName, validNickname, validEmail, validPhone, validServices, validRegions);
-  }, [validName, validNickname, validEmail, validPhone, validServices, validRegions]);
-
   if (isLoading) {
     return (
       <div className="flex min-h-screen items-center justify-center">

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -15,6 +15,7 @@ type TUser = {
   customerImage?: string;
   moverImage?: string;
   provider: "GOOGLE" | "KAKAO" | "NAVER" | "LOCAL";
+  hasBothProfiles: boolean;
 };
 
 export type TSignInResponse = {
@@ -30,6 +31,14 @@ export type TSignInResponse = {
   accessToken: string;
 };
 
+interface ISwitchUserTypeResponse {
+  success: boolean;
+  message: string;
+  oldUserType: "CUSTOMER" | "MOVER";
+  newUserType: "CUSTOMER" | "MOVER";
+  accessToken: string;
+}
+
 interface IAuthContextType {
   user: TUser | null;
   isLoading: boolean;
@@ -41,6 +50,7 @@ interface IAuthContextType {
   naverLogin: (userType: "CUSTOMER" | "MOVER") => Promise<void>;
   logout: () => void;
   getUser: () => Promise<void>;
+  switchUserType: (targetType: "CUSTOMER" | "MOVER") => Promise<ISwitchUserTypeResponse>;
 }
 
 const AuthContext = createContext<IAuthContextType>({
@@ -64,6 +74,13 @@ const AuthContext = createContext<IAuthContextType>({
   naverLogin: async () => {},
   logout: () => {},
   getUser: async () => {},
+  switchUserType: async (): Promise<ISwitchUserTypeResponse> => ({
+    success: false,
+    message: "AuthProvider not found",
+    oldUserType: "CUSTOMER",
+    newUserType: "CUSTOMER",
+    accessToken: "",
+  }),
 });
 
 export const useAuth = () => {
@@ -171,6 +188,27 @@ export default function AuthProvider({ children }: IAuthProviderProps) {
   };
 
   /**
+   *  유저타입 변경 함수
+   */
+
+  const switchUserType = async (targetType: "CUSTOMER" | "MOVER") => {
+    try {
+      setIsLoading(true);
+      const response = await authApi.switchUserType(targetType); // 새로운 토큰 발급
+
+      // 2. 유저 상태 갱신
+      await getUser();
+
+      return response;
+    } catch (error) {
+      console.error("유저 타입 전환 실패:", error);
+      throw error;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  /**
    * 구글 로그인 함수
    */
   const googleLogin = async (userType: "CUSTOMER" | "MOVER") => {
@@ -247,6 +285,7 @@ export default function AuthProvider({ children }: IAuthProviderProps) {
     naverLogin,
     logout,
     getUser,
+    switchUserType,
   };
 
   return <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>;


### PR DESCRIPTION
## ✨ 작업 개요
- 사이드바에가 현재 pathName과 일치할시 텍스트가 강조되지않던 오류 수정
- 간편 로그인 전환 구현
## ✅ 주요 작업 내용
- 간편 로그인 전환 토글 컴포넌트 구현
- 사이드바 컴포넌트 수정

## 🔄 관련 이슈
Closes #191 
Closes #247

## 📸 스크린샷 
### 사이드바
<img width="1046" height="538" alt="사이드바 수정" src="https://github.com/user-attachments/assets/3c5d3264-19ed-43ef-a037-2c3270b0b781" />

### 간편 유저 전환 시연
https://github.com/user-attachments/assets/ac35f658-0cd6-423b-b82a-8e5b349d1ba9

### 간편 유저 전환 잠금 시연
https://github.com/user-attachments/assets/723d3e48-5d94-4f63-a852-9ae9031cf1da

## 🧪 테스트 방법
- 유저 플로우 테스트 필요

## 📝 비고
### 🔒 간편 전환 기능 제한 사유
- 현재 양쪽 역할(CUSTOMER, MOVER) 모두 프로필을 등록한 경우에만 간편 전환이 가능하도록 제한했습니다.
이는 SSR 환경에서 미들웨어가 토큰 갱신 이전 상태로 동작하면서,
프로필이 등록된 계정으로 이동 시 잠깐 /profile/register 페이지가 노출되는 문제가 발생했기 때문입니다.
UX 혼란을 방지하기 위해 해당 조건으로 제한했습니다.