### PR TITLE
fix:토스트 라이브러리를 사용하여 토스트 디자인 변경

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -5,6 +5,7 @@ import { routing } from "@/i18n/routing";
 import Providers from "./providers";
 import { Gnb } from "@/components/common/gnb/Gnb";
 import { ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
@@ -39,6 +40,8 @@ export default async function LocaleLayout({
           pauseOnHover={false}
           draggable={false}
           closeOnClick
+          theme="light"
+          toastClassName="custom-toast"
         />
       </Providers>
     </NextIntlClientProvider>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -310,3 +310,123 @@ body {
   border-radius: 100px;
   opacity: 1;
 }
+
+/* React Toastify 커스텀 스타일 */
+.custom-toast {
+  background: var(--primary-200);
+  color: var(--primary-400);
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  font-family: var(--font-pretendard);
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 1.4;
+  padding: 12px 16px;
+  min-height: auto;
+  margin: 0;
+  width: 100% !important;
+}
+
+.custom-toast .Toastify__toast-body {
+  padding: 0;
+  margin: 0;
+}
+
+.custom-toast .Toastify__close-button {
+  display: none;
+}
+
+.custom-toast .Toastify__close-button:hover {
+  opacity: 1;
+}
+
+/* 토스트 아이콘 스타일링 */
+.custom-toast .Toastify__toast-icon {
+  color: var(--primary-400);
+  font-size: 16px;
+  font-weight: bold;
+}
+
+/* 성공 토스트 아이콘은 브랜드 오렌지 색상 */
+.custom-toast.Toastify__toast--success .Toastify__toast-icon {
+  color: var(--primary-400);
+}
+
+/* react-toastify 기본 성공 아이콘 오버라이드 */
+.custom-toast.Toastify__toast--success .Toastify__toast-icon svg {
+  fill: var(--primary-400);
+}
+
+.custom-toast.Toastify__toast--success .Toastify__toast-icon path {
+  fill: var(--primary-400);
+}
+
+/* 에러 토스트 아이콘은 빨간색 */
+.custom-toast.Toastify__toast--error .Toastify__toast-icon {
+  color: #dc3545;
+}
+
+/* 경고 토스트 아이콘은 노란색 */
+.custom-toast.Toastify__toast--warning .Toastify__toast-icon {
+  color: #ffc107;
+}
+
+/* 성공 토스트 - 브랜드 오렌지 색상 */
+.custom-toast.Toastify__toast--success {
+  background: var(--primary-200);
+  color: var(--primary-400);
+  border-left: 4px solid var(--primary-400);
+}
+
+/* 에러 토스트 - 빨간색으로 구분 */
+.custom-toast.Toastify__toast--error {
+  background: #f8d7da;
+  color: #721c24;
+  border-left: 4px solid #dc3545;
+}
+
+/* 경고 토스트 - 노란색으로 구분 */
+.custom-toast.Toastify__toast--warning {
+  background: #fff3cd;
+  color: #856404;
+  border-left: 4px solid #ffc107;
+}
+
+/* 정보 토스트 - 브랜드 오렌지 색상 */
+.custom-toast.Toastify__toast--info {
+  background: var(--primary-200);
+  color: var(--primary-400);
+  border-left: 4px solid var(--primary-400);
+}
+
+/* 토스트 컨테이너 스타일 */
+.Toastify__toast-container {
+  z-index: 9999;
+}
+
+/* 토스트 애니메이션 커스터마이징 */
+.Toastify__toast-container--top-center {
+  top: 1rem;
+  left: 50% !important;
+  transform: translateX(-50%) !important;
+  width: calc(100% - 24px) !important;
+  max-width: 600px;
+}
+
+/* 반응형 토스트 */
+@media (max-width: 768px) {
+  .custom-toast {
+    font-size: 13px;
+    padding: 10px 14px;
+    margin: 0;
+    width: 100% !important;
+  }
+
+  .Toastify__toast-container--top-center {
+    top: 0.5rem !important;
+    left: 50% !important;
+    transform: translateX(-50%) !important;
+    width: calc(100% - 24px) !important;
+    max-width: none;
+  }
+}

--- a/src/hooks/useEstimateRequestApi.tsx
+++ b/src/hooks/useEstimateRequestApi.tsx
@@ -4,7 +4,7 @@ import { useModal } from "@/components/common/modal/ModalContext";
 import { useTranslations, useLocale } from "next-intl";
 import { estimateRequestClientApi } from "@/lib/api/estimateRequest.client";
 import { IFormState } from "@/types/estimateRequest";
-import { toast } from "react-toastify";
+import { showSuccessToast, showErrorToast } from "@/utils/toastUtils";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { logDevError } from "@/utils/logDevError";
 
@@ -148,7 +148,7 @@ export const useEstimateRequestApi = () => {
         // 세션 데이터 삭제
         localStorage.removeItem("estimateRequest_draft");
         // 견적 생성 성공 토스트 표시
-        toast.success(t("estimateRequest.createSuccess"));
+        showSuccessToast(t("estimateRequest.createSuccess"));
         // 토스트를 잠시 보여준 후 페이지 새로고침 (한 번만)
         setTimeout(() => {
           window.location.reload();
@@ -168,7 +168,7 @@ export const useEstimateRequestApi = () => {
         // 세션 데이터 삭제
         localStorage.removeItem("estimateRequest_draft");
         // 견적 수정 성공 토스트 표시
-        toast.success(t("estimateRequest.editSuccess"));
+        showSuccessToast(t("estimateRequest.editSuccess"));
         // 토스트를 잠시 보여준 후 페이지 새로고침 (한 번만)
         setTimeout(() => {
           window.location.reload();
@@ -196,7 +196,7 @@ export const useEstimateRequestApi = () => {
         // 세션 데이터 삭제
         localStorage.removeItem("estimateRequest_draft");
         // 삭제 성공 토스트 표시
-        toast.success(t("estimateRequest.deleteSuccess"));
+        showSuccessToast(t("estimateRequest.deleteSuccess"));
         // 토스트를 잠시 보여준 후 페이지 새로고침 (한 번만)
         setTimeout(() => {
           window.location.reload();

--- a/src/hooks/useSwitchUserType.tsx
+++ b/src/hooks/useSwitchUserType.tsx
@@ -2,7 +2,7 @@
 import { useMutation } from "@tanstack/react-query";
 import { useAuth } from "@/providers/AuthProvider";
 import authApi from "@/lib/api/auth.api";
-import { toast } from "react-toastify";
+import { showSuccessToast, showErrorToast } from "@/utils/toastUtils";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 
@@ -20,9 +20,9 @@ export const useSwitchUserType = () => {
     onSuccess: async (res) => {
       // 토스트 메시지
       if (res.newUserType === "CUSTOMER") {
-        toast.success(t("customerSuccessToast"));
+        showSuccessToast(t("customerSuccessToast"));
       } else {
-        toast.success(t("moverSuccessToast"));
+        showSuccessToast(t("moverSuccessToast"));
       }
 
       // 유저 정보 다시 불러오기
@@ -35,7 +35,7 @@ export const useSwitchUserType = () => {
       }
     },
     onError: (err: Error) => {
-      toast.error(err?.message || t("switchUserTypeError"));
+      showErrorToast(err?.message || t("switchUserTypeError"));
     },
   });
 };

--- a/src/pageComponents/favoriteMover/FavoriteMoverPage.tsx
+++ b/src/pageComponents/favoriteMover/FavoriteMoverPage.tsx
@@ -5,7 +5,7 @@ import SectionHeader from "@/components/common/SectionHeader";
 import MoverCard from "@/components/searchMover/MoverCard";
 import findMoverApi from "@/lib/api/findMover.api";
 import { IMoverInfo } from "@/types/mover.types";
-import { toast } from "react-toastify";
+import { showSuccessToast, showErrorToast } from "@/utils/toastUtils";
 import MovingTruckLoader from "@/components/common/pending/MovingTruckLoader";
 
 const FavoriteMoverPage = () => {
@@ -74,11 +74,11 @@ const FavoriteMoverPage = () => {
       setSelectAll(false);
 
       // 성공 토스트 표시
-      toast.success(`${selectedMovers.size}${t("deleteSuccess")}`);
+      showSuccessToast(`${selectedMovers.size}${t("deleteSuccess")}`);
     } catch (error) {
       console.error("선택된 항목 삭제 실패:", error);
       // 에러 토스트 표시
-      toast.error(t("deleteError"));
+      showErrorToast(t("deleteError"));
     } finally {
       setDeleting(false);
     }

--- a/src/utils/shareUtils.ts
+++ b/src/utils/shareUtils.ts
@@ -1,4 +1,5 @@
 import logo from "@/assets/img/logo/logo-m.png";
+import { showSuccessToast, showErrorToast } from "@/utils/toastUtils";
 /**
  * 공유 관련 유틸리티 함수들
  */
@@ -160,18 +161,6 @@ export const shareToFacebook = (url: string, title?: string, description?: strin
 
 // 공유 성공 알림 표시
 export const showShareSuccess = (type: "clip" | "kakao" | "facebook"): void => {
-  // 이미 존재하는 알림 제거
-  const existingAlert = document.getElementById("share-success-alert");
-  if (existingAlert) {
-    existingAlert.remove();
-  }
-
-  // 새로운 알림 생성
-  const alert = document.createElement("div");
-  alert.id = "share-success-alert";
-  alert.className =
-    "w-full max-w-[320px] md:max-w-[660px] lg:max-w-[1200px] h-[54px] lg:h-[66px] fixed top-4 left-1/2 transform -translate-x-1/2 z-50 bg-primary-200 text-primary-400 px-4 py-2 leading-[26px] font-semibold text-[16px] rounded-lg shadow-lg transition-all duration-300 items-center justify-center py-[16px] lg:py-[22px] pl-[24px] md:pl-[32px]";
-
   let message = "";
   switch (type) {
     case "clip":
@@ -185,37 +174,10 @@ export const showShareSuccess = (type: "clip" | "kakao" | "facebook"): void => {
       break;
   }
 
-  alert.textContent = message;
-  document.body.appendChild(alert);
-
-  // 3초 후 알림 제거
-  setTimeout(() => {
-    if (alert.parentNode) {
-      alert.parentNode.removeChild(alert);
-    }
-  }, 3000);
+  showSuccessToast(message);
 };
 
 // 공유 실패 알림 표시
 export const showShareError = (message: string): void => {
-  // 이미 존재하는 알림 제거
-  const existingAlert = document.getElementById("share-error-alert");
-  if (existingAlert) {
-    existingAlert.remove();
-  }
-
-  // 새로운 알림 생성
-  const alert = document.createElement("div");
-  alert.id = "share-error-alert";
-  alert.className =
-    "fixed top-4 left-1/2 transform -translate-x-1/2 z-50 bg-red-600 text-white px-4 py-2 rounded-lg shadow-lg transition-all duration-300 flex items-center justify-center";
-  alert.textContent = message;
-  document.body.appendChild(alert);
-
-  // 3초 후 알림 제거
-  setTimeout(() => {
-    if (alert.parentNode) {
-      alert.parentNode.removeChild(alert);
-    }
-  }, 3000);
+  showErrorToast(message);
 };

--- a/src/utils/toastUtils.ts
+++ b/src/utils/toastUtils.ts
@@ -1,0 +1,97 @@
+import { toast } from "react-toastify";
+
+/**
+ * 성공 토스트 알림 (브랜드 오렌지 색상 + 체크 아이콘)
+ * @param message - 표시할 메시지
+ * @param options - 추가 옵션
+ */
+export const showSuccessToast = (message: string, options?: any) => {
+  toast.success(message, {
+    position: "top-center",
+    autoClose: 2000,
+    hideProgressBar: true,
+    closeOnClick: true,
+    pauseOnHover: false,
+    draggable: false,
+    icon: "✓",
+    ...options,
+  });
+};
+
+/**
+ * 에러 토스트 알림 (빨간색 + X 아이콘)
+ * @param message - 표시할 메시지
+ * @param options - 추가 옵션
+ */
+export const showErrorToast = (message: string, options?: any) => {
+  toast.error(message, {
+    position: "top-center",
+    autoClose: 3000,
+    hideProgressBar: true,
+    closeOnClick: true,
+    pauseOnHover: false,
+    draggable: false,
+    icon: "✕",
+    ...options,
+  });
+};
+
+/**
+ * 경고 토스트 알림
+ * @param message - 표시할 메시지
+ * @param options - 추가 옵션
+ */
+export const showWarningToast = (message: string, options?: any) => {
+  toast.warning(message, {
+    position: "top-center",
+    autoClose: 2500,
+    hideProgressBar: true,
+    closeOnClick: true,
+    pauseOnHover: false,
+    draggable: false,
+    ...options,
+  });
+};
+
+/**
+ * 정보 토스트 알림 (브랜드 오렌지 색상 + 정보 아이콘)
+ * @param message - 표시할 메시지
+ * @param options - 추가 옵션
+ */
+export const showInfoToast = (message: string, options?: any) => {
+  toast.info(message, {
+    position: "top-center",
+    autoClose: 2000,
+    hideProgressBar: true,
+    closeOnClick: true,
+    pauseOnHover: false,
+    draggable: false,
+    icon: "ℹ",
+    ...options,
+  });
+};
+
+/**
+ * 기본 토스트 알림 (브랜드 오렌지 색상)
+ * @param message - 표시할 메시지
+ * @param options - 추가 옵션
+ */
+export const showCustomToast = (message: string, options?: any) => {
+  toast(message, {
+    position: "top-center",
+    autoClose: 2000,
+    hideProgressBar: true,
+    closeOnClick: true,
+    pauseOnHover: false,
+    draggable: false,
+    icon: "✓",
+    ...options,
+  });
+};
+
+/**
+ * 모든 토스트 제거
+ */
+export const clearAllToasts = () => {
+  toast.dismiss();
+};


### PR DESCRIPTION
## ✨ 작업 개요
- 전역상태로 구현되어 있던 토스트 라이브러리를 활용하여 프로젝트에 맞는 디자인으로 수정

## ✅ 주요 작업 내용
- 토스트 라이브러리 디자인 임포트
- 디자인 수정
- 토스트 알림을 사용하는 모든 페이지 변경

## 🔄 관련 이슈

## 📸 스크린샷 (선택)
<img width="1897" height="941" alt="image" src="https://github.com/user-attachments/assets/8683cb74-3cec-41b0-96c0-8448701d5091" />

## 🧪 테스트 방법 (선택)

## 📝 비고
