### PR TITLE
[#301] [#302] [알림] 데이터 리패칭 문제 해결 및 FE 다국어 처리.

### DIFF
--- a/src/components/common/gnb/GnbActions.tsx
+++ b/src/components/common/gnb/GnbActions.tsx
@@ -11,7 +11,7 @@ import { TUserRole } from "@/types/user.types";
 import NotificationList from "@/components/notification/NotificationList";
 import UserActionDropdown from "../dropdown/UserActionDropdown";
 import { useNotificationStore } from "@/stores/notificationStore";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import ProfileModal from "./ProfileModal";
 
 interface IGnbActionsProps {
@@ -36,6 +36,7 @@ export const GnbActions = ({
   profileImage,
 }: IGnbActionsProps) => {
   const t = useTranslations();
+  const locale = useLocale();
 
   const [isProfileOpen, setIsProfileOpen] = useState(false);
 
@@ -54,7 +55,7 @@ export const GnbActions = ({
       closeNotificationModal();
     } else {
       openNotificationModal();
-      fetchNotifications(4, 0); // 모달이 열릴 때만 전체 알림(첫 페이지) 받아오기
+      fetchNotifications(4, 0, locale); // 모달이 열릴 때만 전체 알림(첫 페이지) 받아오기
     }
   };
 
@@ -112,16 +113,16 @@ export const GnbActions = ({
   useEffect(() => {
     if (userRole !== "GUEST") {
       // 헤더가 보일 때(마운트 시) 최신 알림 1개만 받아와서 hasUnread만 갱신
-      fetchNotifications(1, 0);
+      fetchNotifications(1, 0, locale);
     }
-  }, [userRole, fetchNotifications]);
+  }, [userRole, fetchNotifications, locale]);
 
   // 알림 모달이 열릴 때마다 최신 상태로 동기화
   useEffect(() => {
     if (isNotificationOpen && userRole !== "GUEST") {
-      fetchNotifications(4, 0);
+      fetchNotifications(4, 0, locale);
     }
-  }, [isNotificationOpen, userRole, fetchNotifications]);
+  }, [isNotificationOpen, userRole, fetchNotifications, locale]);
 
   // userRole이나 userName 변경 시 프로필 모달 상태 초기화
   useEffect(() => {

--- a/src/components/notification/NotificationList.tsx
+++ b/src/components/notification/NotificationList.tsx
@@ -8,7 +8,8 @@ import parse from "html-react-parser";
 import { useRouter } from "next/navigation";
 import { INotification } from "@/types/notification.types";
 import { useTranslations } from "next-intl";
-import { formatRelativeTime } from "@/utils/dateUtils";
+import { formatRelativeTimeWithTranslations } from "@/utils/dateUtils";
+import { useLocale } from "next-intl";
 
 export default function NotificationList({ onClose }: { onClose?: () => void }) {
   const notifications = useNotificationStore((state) => state.notifications);
@@ -20,15 +21,24 @@ export default function NotificationList({ onClose }: { onClose?: () => void }) 
   const loadingRef = useRef(false);
   const router = useRouter();
   const t = useTranslations("notification");
+  const locale = useLocale();
+
+  // 시간 번역 가져오기
+  const timeTranslations = {
+    justNow: t("time.justNow"),
+    minutesAgo: t("time.minutesAgo"),
+    hoursAgo: t("time.hoursAgo"),
+    daysAgo: t("time.daysAgo"),
+  };
 
   const { ref, inView } = useInView({ threshold: 0.2 });
 
   const loadMore = useCallback(async () => {
     if (loadingRef.current) return;
     loadingRef.current = true;
-    await fetchNotifications(limit, notifications.length);
+    await fetchNotifications(limit, notifications.length, locale);
     loadingRef.current = false;
-  }, [fetchNotifications, notifications.length, limit]);
+  }, [fetchNotifications, notifications.length, limit, locale]);
 
   useEffect(() => {
     if (inView && hasMore && !loadingRef.current) {
@@ -75,13 +85,11 @@ export default function NotificationList({ onClose }: { onClose?: () => void }) 
                     handleClick(notification);
                   }
                 }}
-                aria-label={`${parse(DOMPurify.sanitize(notification.title))} - ${formatRelativeTime(new Date(notification.createdAt))}`}
+                aria-label={`${parse(DOMPurify.sanitize(notification.title))} - ${formatRelativeTimeWithTranslations(new Date(notification.createdAt), timeTranslations, locale === "ko" ? "ko-KR" : locale === "en" ? "en-US" : "zh-CN")}`}
               >
-                <header className="text-sm break-words">
-                  {parse(DOMPurify.sanitize(notification.title))}
-                </header>
+                <header className="text-sm break-words">{parse(DOMPurify.sanitize(notification.title))}</header>
                 <time className="mt-1 text-xs text-gray-400" dateTime={notification.createdAt}>
-                  {formatRelativeTime(new Date(notification.createdAt))}
+                  {formatRelativeTimeWithTranslations(new Date(notification.createdAt), timeTranslations, locale === "ko" ? "ko-KR" : locale === "en" ? "en-US" : "zh-CN")}
                 </time>
               </article>
             ) : (
@@ -90,11 +98,9 @@ export default function NotificationList({ onClose }: { onClose?: () => void }) 
                   idx !== notifications.length - 1 ? "border-b border-gray-200" : ""
                 }`}
               >
-                <header className="text-sm break-words">
-                  {parse(DOMPurify.sanitize(notification.title))}
-                </header>
+                <header className="text-sm break-words">{parse(DOMPurify.sanitize(notification.title))}</header>
                 <time className="mt-1 text-xs text-gray-400" dateTime={notification.createdAt}>
-                  {formatRelativeTime(new Date(notification.createdAt))}
+                  {formatRelativeTimeWithTranslations(new Date(notification.createdAt), timeTranslations, locale === "ko" ? "ko-KR" : locale === "en" ? "en-US" : "zh-CN")}
                 </time>
               </article>
             )}

--- a/src/lib/api/notification.api.ts
+++ b/src/lib/api/notification.api.ts
@@ -21,8 +21,8 @@ export interface NotificationApiResponse {
 }
 
 // 알림 목록 조회
-export async function getNotifications(limit = 3, offset = 0): Promise<NotificationApiResponse> {
-  const res = await fetch(`${API_URL}/notifications?limit=${limit}&offset=${offset}`, {
+export async function getNotifications(limit = 3, offset = 0, lang: string = "ko"): Promise<NotificationApiResponse> {
+  const res = await fetch(`${API_URL}/notifications?limit=${limit}&offset=${offset}&lang=${lang}`, {
     credentials: "include",
     headers: {
       "Content-Type": "application/json",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -887,7 +887,13 @@
   "notification": {
     "title": "Notifications",
     "noNotifications": "No notifications yet!",
-    "allNotificationsLoaded": "All notifications loaded."
+    "allNotificationsLoaded": "All notifications loaded.",
+    "time": {
+      "justNow": "Just now",
+      "minutesAgo": " minutes ago",
+      "hoursAgo": " hours ago",
+      "daysAgo": " days ago"
+    }
   },
   "schedule": {
     "metadata": {

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -860,7 +860,13 @@
   "notification": {
     "title": "알림",
     "noNotifications": "아직 알림이 없어요!",
-    "allNotificationsLoaded": "모든 알림을 불러왔습니다."
+    "allNotificationsLoaded": "모든 알림을 불러왔습니다.",
+    "time": {
+      "justNow": "방금 전",
+      "minutesAgo": "분 전",
+      "hoursAgo": "시간 전",
+      "daysAgo": "일 전"
+    }
   },
   "schedule": {
     "metadata": {

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -900,7 +900,13 @@
   "notification": {
     "title": "通知",
     "noNotifications": "还没有通知！",
-    "allNotificationsLoaded": "已加载所有通知。"
+    "allNotificationsLoaded": "已加载所有通知。",
+    "time": {
+      "justNow": "刚刚",
+      "minutesAgo": " 分钟前",
+      "hoursAgo": " 小时前",
+      "daysAgo": " 天前"
+    }
   },
   "schedule": {
     "metadata": {


### PR DESCRIPTION
## ✨ 작업 개요
- 데이터 리패칭 문제 해결 및 FE 다국어 처리.

## ✅ 주요 작업 내용
- SSE가 재연결을 리랜더링 될때마다 진행해 발생한 알림 데이터를 무한 리패칭하는 문제를 유저id가 바뀔때만 재연결하여 해결.  
- deepL을 BE에서 처리하기 때문에 FE에선 쿼리파라미터로 언어만 넘겨주어 다국어 처리.

## 🔄 관련 이슈
Closes #301 - 다국어 작업.
Closes #302 - 데이터 리패칭 지옥.
