### PR TITLE
[#309] [알림] 일반 유저와 기사님 알림 따로 처리.

### DIFF
--- a/src/components/common/gnb/GnbActions.tsx
+++ b/src/components/common/gnb/GnbActions.tsx
@@ -11,6 +11,7 @@ import { TUserRole } from "@/types/user.types";
 import NotificationList from "@/components/notification/NotificationList";
 import UserActionDropdown from "../dropdown/UserActionDropdown";
 import { useNotificationStore } from "@/stores/notificationStore";
+import { useAuth } from "@/providers/AuthProvider";
 import { useTranslations, useLocale } from "next-intl";
 import ProfileModal from "./ProfileModal";
 
@@ -49,13 +50,14 @@ export const GnbActions = ({
   const fetchNotifications = useNotificationStore((state) => state.fetchNotifications);
   const openNotificationModal = useNotificationStore((state) => state.openNotificationModal);
   const closeNotificationModal = useNotificationStore((state) => state.closeNotificationModal);
+  const { user } = useAuth();
 
   const handleNotificationClick = () => {
     if (isNotificationOpen) {
       closeNotificationModal();
     } else {
       openNotificationModal();
-      fetchNotifications(4, 0, locale); // 모달이 열릴 때만 전체 알림(첫 페이지) 받아오기
+      fetchNotifications(4, 0, locale, user?.userType); // 모달이 열릴 때만 전체 알림(첫 페이지) 받아오기
     }
   };
 
@@ -113,16 +115,16 @@ export const GnbActions = ({
   useEffect(() => {
     if (userRole !== "GUEST") {
       // 헤더가 보일 때(마운트 시) 최신 알림 1개만 받아와서 hasUnread만 갱신
-      fetchNotifications(1, 0, locale);
+      fetchNotifications(1, 0, locale, user?.userType);
     }
-  }, [userRole, fetchNotifications, locale]);
+  }, [userRole, fetchNotifications, locale, user?.userType]);
 
   // 알림 모달이 열릴 때마다 최신 상태로 동기화
   useEffect(() => {
     if (isNotificationOpen && userRole !== "GUEST") {
-      fetchNotifications(4, 0, locale);
+      fetchNotifications(4, 0, locale, user?.userType);
     }
-  }, [isNotificationOpen, userRole, fetchNotifications, locale]);
+  }, [isNotificationOpen, userRole, fetchNotifications, locale, user?.userType]);
 
   // userRole이나 userName 변경 시 프로필 모달 상태 초기화
   useEffect(() => {

--- a/src/components/notification/NotificationList.tsx
+++ b/src/components/notification/NotificationList.tsx
@@ -10,6 +10,7 @@ import { INotification } from "@/types/notification.types";
 import { useTranslations } from "next-intl";
 import { formatRelativeTimeWithTranslations } from "@/utils/dateUtils";
 import { useLocale } from "next-intl";
+import { useAuth } from "@/providers/AuthProvider";
 
 export default function NotificationList({ onClose }: { onClose?: () => void }) {
   const notifications = useNotificationStore((state) => state.notifications);
@@ -22,6 +23,7 @@ export default function NotificationList({ onClose }: { onClose?: () => void }) 
   const router = useRouter();
   const t = useTranslations("notification");
   const locale = useLocale();
+  const { user } = useAuth();
 
   // 시간 번역 가져오기
   const timeTranslations = {
@@ -36,9 +38,9 @@ export default function NotificationList({ onClose }: { onClose?: () => void }) 
   const loadMore = useCallback(async () => {
     if (loadingRef.current) return;
     loadingRef.current = true;
-    await fetchNotifications(limit, notifications.length, locale);
+    await fetchNotifications(limit, notifications.length, locale, user?.userType);
     loadingRef.current = false;
-  }, [fetchNotifications, notifications.length, limit, locale]);
+  }, [fetchNotifications, notifications.length, limit, locale, user?.userType]);
 
   useEffect(() => {
     if (inView && hasMore && !loadingRef.current) {
@@ -49,7 +51,7 @@ export default function NotificationList({ onClose }: { onClose?: () => void }) 
   // 알림 클릭 핸들러 -> 읽음처리 후 이동.
   const handleClick = async (notification: INotification) => {
     try {
-      await markAsRead(notification.id);
+      await markAsRead(notification.id, user?.userType);
       onClose?.();
       closeNotificationModal();
       router.push(notification.path);

--- a/src/lib/api/notification.api.ts
+++ b/src/lib/api/notification.api.ts
@@ -21,8 +21,16 @@ export interface NotificationApiResponse {
 }
 
 // 알림 목록 조회
-export async function getNotifications(limit = 3, offset = 0, lang: string = "ko"): Promise<NotificationApiResponse> {
-  const res = await fetch(`${API_URL}/notifications?limit=${limit}&offset=${offset}&lang=${lang}`, {
+export async function getNotifications(limit = 3, offset = 0, lang: string = "ko", userType?: string): Promise<NotificationApiResponse> {
+  const queryParams = new URLSearchParams();
+  queryParams.append("limit", limit.toString());
+  queryParams.append("offset", offset.toString());
+  queryParams.append("lang", lang);
+  if (userType) {
+    queryParams.append("userType", userType);
+  }
+
+  const res = await fetch(`${API_URL}/notifications?${queryParams.toString()}`, {
     credentials: "include",
     headers: {
       "Content-Type": "application/json",

--- a/src/stores/notificationStore.ts
+++ b/src/stores/notificationStore.ts
@@ -14,8 +14,8 @@ interface INotificationState {
   addNotification: (noti: INotification) => void;
   connectSSE: (token: string) => void;
   disconnectSSE: () => void;
-  fetchNotifications: (limit?: number, offset?: number, lang?: string) => Promise<void>;
-  markAsRead: (id: string) => Promise<void>;
+  fetchNotifications: (limit?: number, offset?: number, lang?: string, userType?: string) => Promise<void>;
+  markAsRead: (id: string, userType?: string) => Promise<void>;
   markAllAsRead: () => Promise<void>;
   openNotificationModal: () => void;
   closeNotificationModal: () => void;
@@ -144,9 +144,9 @@ export const useNotificationStore = create<INotificationState>((set, get) => ({
     set({ isSSEConnected: false });
   },
   // --- API 연동 부분 ---
-  fetchNotifications: async (limit = 3, offset = 0, lang: string = "ko") => {
+  fetchNotifications: async (limit = 3, offset = 0, lang: string = "ko", userType?: string) => {
     try {
-      const res = await getNotifications(limit, offset, lang);
+      const res = await getNotifications(limit, offset, lang, userType);
       set((state) => {
         let newNotifications;
         if (offset === 0) {
@@ -168,11 +168,11 @@ export const useNotificationStore = create<INotificationState>((set, get) => ({
       console.error("알림 가져오기 실패:", error);
     }
   },
-  markAsRead: async (id: string) => {
+  markAsRead: async (id: string, userType?: string) => {
     try {
       await readNotification(id);
       // 읽음 처리 후 최신 상태로 동기화
-      await get().fetchNotifications();
+      await get().fetchNotifications(3, 0, "ko", userType);
     } catch (error) {
       console.error("알림 읽음 처리 실패:", error);
     }


### PR DESCRIPTION
## ✨ 작업 개요
- 일반 유저와 기사님 알림 따로 처리.

## ✅ 주요 작업 내용
- 일반 유저와 기사님에 모두 해당하는 유저는 각각의 알림을 따로 받도록 유저 타입 추가.
- 쿼리 파라미터로 유저타입 전달.

## 🔄 관련 이슈
Closes #309 