### PR TITLE
feat:CSRF를 위한 공통 유틸 함수 제작

### DIFF
--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -1,0 +1,108 @@
+// API 호출 공통 헬퍼 함수
+import { getTokenFromCookie } from "@/utils/auth";
+import { getCSRFTokenFromCookie, getCSRFToken } from "@/utils/csrf";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5050";
+
+// 인증 헤더를 가져오는 함수
+export const getAuthHeaders = async (
+  additionalHeaders: Record<string, string> = {},
+): Promise<Record<string, string>> => {
+  const accessToken = await getTokenFromCookie();
+
+  // CSRF 토큰 가져오기
+  let csrfToken = getCSRFTokenFromCookie();
+  if (!csrfToken) {
+    csrfToken = await getCSRFToken();
+  }
+
+  return {
+    "Content-Type": "application/json",
+    ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
+    ...(csrfToken && { "X-XSRF-TOKEN": csrfToken }),
+    ...additionalHeaders,
+  };
+};
+
+// API 호출 공통 함수
+export const apiRequest = async <T = any>(endpoint: string, options: RequestInit = {}, retry = true): Promise<T> => {
+  try {
+    const headers = await getAuthHeaders(options.headers as Record<string, string>);
+    const url = `${API_BASE_URL}${endpoint}`;
+
+    console.log("API 호출 정보:", {
+      url,
+      method: options.method || "GET",
+      headers,
+      body: options.body,
+    });
+
+    const response = await fetch(url, {
+      ...options,
+      headers,
+      credentials: "include", // refreshToken 쿠키 필요 시 포함
+    });
+
+    console.log("API 응답 상태:", response.status, response.statusText);
+
+    // 401 Unauthorized → accessToken 만료 가능성
+    if (response.status === 401 && retry) {
+      // 토큰 재발급 로직 (필요시 구현)
+      // await authApi.refreshToken();
+      // return apiRequest<T>(endpoint, options, false);
+    }
+
+    if (response.status === 404) {
+      // refreshToken도 만료 → 로그아웃 처리
+      // authApi.logout();
+      throw new Error("로그인이 만료되었습니다.");
+    }
+
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.message || "API 요청 실패");
+    }
+
+    const data = await response.json();
+    console.log("API 응답 데이터:", data);
+
+    return data;
+  } catch (error) {
+    console.error("API 호출 오류:", error);
+    throw error;
+  }
+};
+
+// GET 요청 헬퍼
+export const apiGet = async <T = any>(endpoint: string): Promise<T> => {
+  return apiRequest<T>(endpoint, { method: "GET" });
+};
+
+// POST 요청 헬퍼
+export const apiPost = async <T = any>(endpoint: string, body: any): Promise<T> => {
+  return apiRequest<T>(endpoint, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+};
+
+// PUT 요청 헬퍼
+export const apiPut = async <T = any>(endpoint: string, body: any): Promise<T> => {
+  return apiRequest<T>(endpoint, {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+};
+
+// DELETE 요청 헬퍼
+export const apiDelete = async <T = any>(endpoint: string): Promise<T> => {
+  return apiRequest<T>(endpoint, { method: "DELETE" });
+};
+
+// PATCH 요청 헬퍼
+export const apiPatch = async <T = any>(endpoint: string, body: any): Promise<T> => {
+  return apiRequest<T>(endpoint, {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+};

--- a/src/utils/csrf.ts
+++ b/src/utils/csrf.ts
@@ -1,0 +1,42 @@
+// CSRF 토큰 관리 유틸리티
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5050";
+
+// CSRF 토큰을 가져오는 함수
+export const getCSRFToken = async (): Promise<string | null> => {
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/csrf/token`, {
+      method: "GET",
+      credentials: "include", // 쿠키 포함
+    });
+
+    if (!response.ok) {
+      console.error("CSRF 토큰 조회 실패:", response.status);
+      return null;
+    }
+
+    const data = await response.json();
+    return data.data?.token || null;
+  } catch (error) {
+    console.error("CSRF 토큰 조회 중 오류:", error);
+    return null;
+  }
+};
+
+// 쿠키에서 CSRF 토큰을 가져오는 함수
+export const getCSRFTokenFromCookie = (): string | null => {
+  if (typeof document === "undefined") return null;
+
+  const cookies = document.cookie.split(";");
+  const xsrfCookie = cookies.find((cookie) => cookie.trim().startsWith("XSRF-TOKEN="));
+
+  if (xsrfCookie) {
+    return xsrfCookie.split("=")[1];
+  }
+
+  return null;
+};
+
+// CSRF 토큰이 유효한지 확인하는 함수
+export const isCSRFTokenValid = (token: string | null): boolean => {
+  return token !== null && token.length > 0;
+};


### PR DESCRIPTION
## ✨ 작업 개요
- CSRF 도입으로 바로 사용할 수 있는 공통 헬퍼 함수 제작

## ✅ 주요 작업 내용
- 공통 헬퍼 함수 제작

## 🔄 관련 이슈
## 📝 비고
```
// Moving_FE/src/lib/api/fetcher.api.ts 수정
import { apiRequest } from "@/utils/apiHelpers";

export const fetchWithAuth = async <T = any>(input: RequestInfo, init: RequestInit = {}, retry = true): Promise<T> => {
  // input이 전체 URL인 경우 endpoint 추출
  const endpoint = typeof input === 'string' ? input.replace(API_BASE_URL, '') : '';
  
  return apiRequest<T>(endpoint, init, retry);
};
```
이런식으로 헬퍼 함수를 임포트하고 apiRequest로 호출