### PR TITLE
fix : 경고/에러 토스트 모달로 변경 및 로그인/회원가입 번역을 자체 번역으로 변경

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -3,11 +3,16 @@
 import React, { useEffect } from "react";
 import Image from "next/image";
 import NotFoundImage from "@/assets/img/etc/notfound.webp";
+import { logDevError } from "@/utils/logDevError";
+import * as Sentry from "@sentry/nextjs";
 
 export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
   useEffect(() => {
     // 에러를 에러 리포팅 서비스에 로그
-    console.error(error);
+    logDevError(error, "Error");
+
+    // ✅ Sentry로 전송
+    Sentry.captureException(error);
   }, [error]);
 
   return (

--- a/src/components/auth/signin/SigninForm.tsx
+++ b/src/components/auth/signin/SigninForm.tsx
@@ -6,12 +6,14 @@ import { BaseInput } from "@/components/common/input/BaseInput";
 import { PasswordInput } from "@/components/common/input/PasswordInput";
 import { ISignInFormValues } from "@/types/auth";
 import { useAuth } from "@/providers/AuthProvider";
-import { useModal } from "@/components/common/modal/ModalContext";
 import { useValidationRules } from "@/hooks/useValidationRules";
 import { useLocale, useTranslations } from "next-intl";
 import { TUserType } from "@/types/user";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { ValidationErrorToast } from "@/components/common/modal/ValidationErrorToast";
+import { showErrorToast } from "@/utils/toastUtils";
+import { handleAuthErrorToast } from "@/utils/handleAuthErrorToast";
 
 interface ISigninFormProps {
   userType: TUserType;
@@ -22,7 +24,6 @@ const SigninForm = ({ userType, signupLink }: ISigninFormProps) => {
   const router = useRouter();
   const { login, isLoading } = useAuth();
   const validationRules = useValidationRules();
-  const { open, close } = useModal();
   const t = useTranslations("auth");
   const currentLocale = useLocale();
 
@@ -47,11 +48,7 @@ const SigninForm = ({ userType, signupLink }: ISigninFormProps) => {
       if (isLoading) return;
       const response = await login(email, password, userType);
       if (!response.success) {
-        open({
-          title: t("loginFailed"),
-          children: <div>{response.message}</div>,
-          buttons: [{ text: t("confirm"), onClick: () => close() }],
-        });
+        handleAuthErrorToast(t, response.message);
       } else {
         if (userType === "CUSTOMER") {
           router.push(`/${currentLocale}/searchMover`);

--- a/src/components/auth/signup/SignupForm.tsx
+++ b/src/components/auth/signup/SignupForm.tsx
@@ -6,11 +6,13 @@ import { BaseInput } from "@/components/common/input/BaseInput";
 import { PasswordInput } from "@/components/common/input/PasswordInput";
 import { ISignUpFormValues } from "@/types/auth";
 import { useAuth } from "@/providers/AuthProvider";
-import { useModal } from "@/components/common/modal/ModalContext";
 import { useValidationRules } from "@/hooks/useValidationRules";
 import { useLocale, useTranslations } from "next-intl";
 import { TUserType } from "@/types/user";
 import { useRouter } from "next/navigation";
+import { ValidationErrorToast } from "@/components/common/modal/ValidationErrorToast";
+import { showErrorToast } from "@/utils/toastUtils";
+import { handleAuthErrorToast } from "@/utils/handleAuthErrorToast";
 
 interface ISignupFormProps {
   userType: TUserType;
@@ -21,7 +23,6 @@ const SignupForm = ({ userType, signinLink }: ISignupFormProps) => {
   const router = useRouter();
   const { signUp, isLoading } = useAuth();
   const validationRules = useValidationRules();
-  const { open, close } = useModal();
   const t = useTranslations("auth");
   const currentLocale = useLocale();
 
@@ -58,12 +59,9 @@ const SignupForm = ({ userType, signinLink }: ISignupFormProps) => {
     try {
       if (isLoading) return;
       const response = await signUp(signUpData);
+
       if (!response.success) {
-        open({
-          title: "회원가입 실패",
-          children: <div>{response.message}</div>,
-          buttons: [{ text: "확인", onClick: () => close() }],
-        });
+        handleAuthErrorToast(t, response.message);
       } else {
         if (userType === "CUSTOMER") {
           router.push(`/${currentLocale}/searchMover`);

--- a/src/components/profile/edit/ProfileEditImageUpload.tsx
+++ b/src/components/profile/edit/ProfileEditImageUpload.tsx
@@ -4,6 +4,7 @@ import React, { useRef } from "react";
 import Image from "next/image";
 import { useTranslations } from "next-intl";
 import userApi from "@/lib/api/user.api";
+import { showWarningToast } from "@/utils/toastUtils";
 
 interface IProfileEditImageUploadProps {
   selectedImage: { name: string; type: string; dataUrl: string };
@@ -28,6 +29,12 @@ export const ProfileEditImageUpload = ({
   const handleImageChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file) return;
+
+    // ✅ 이미지 파일인지 확인
+    if (!file.type.startsWith("image/")) {
+      showWarningToast(t("imageUploadError"));
+      return;
+    }
 
     const fileUrl = await userApi.uploadFilesToS3(file);
     onImageChange({

--- a/src/components/profile/register/ProfileImageUpload.tsx
+++ b/src/components/profile/register/ProfileImageUpload.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import React, { useRef } from "react";
 import userApi from "@/lib/api/user.api";
 import { useTranslations } from "next-intl";
+import { showWarningToast } from "@/utils/toastUtils";
 
 interface IProfileImageUploadProps {
   uploadSkeleton: string;
@@ -28,6 +29,12 @@ export const ProfileImageUpload = ({
   const handleImageChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file) return;
+
+    // ✅ 이미지 파일인지 확인
+    if (!file.type.startsWith("image/")) {
+      showWarningToast(t("imageUploadError"));
+      return;
+    }
 
     const fileUrl = await userApi.uploadFilesToS3(file);
 

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -378,7 +378,8 @@
       "description": "Profile registration page"
     },
     "registerLoadingText": "Loading profile registration page...",
-    "editLoadingText": "Loading profile edit page..."
+    "editLoadingText": "Loading profile edit page...",
+    "imageUploadError": "Only image files can be uploaded."
   },
   "search": {
     "title": "Search Moving Companies",
@@ -636,6 +637,22 @@
     "moverSignupMetadata": {
       "title": "Mover Signup | Moving",
       "description": "This is the signup page for movers."
+    },
+    "error": {
+      "userNotFound": "User does not exist.",
+      "socialLoginOnly": "This is a social login account. Please sign in using the corresponding platform.",
+      "invalidPassword": "Incorrect password.",
+      "duplicateEmail": "This email is already in use.",
+      "invalidEmailFormat": "Invalid email format.",
+      "nameTooShort": "Name must be at least 2 characters.",
+      "passwordTooShort": "Password must be at least 8 characters.",
+      "passwordWeak": "Password must include letters, numbers, and special characters.",
+      "invalidPhoneNumber": "Phone number must contain only digits.",
+      "phoneTooShort": "Phone number must be at least 10 digits.",
+      "tokenGeneration": "Login failed. Please try again later.",
+      "userCreationFailed": "Signup failed. Please try again later.",
+      "tokenInvalid": "Token authentication failed. Please log in again.",
+      "unknown": "An unknown error occurred. Please try again."
     }
   },
   "landing": {

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -353,7 +353,8 @@
       "description": "프로필 등록 페이지"
     },
     "registerLoadingText": "프로필 등록 페이지 불러오는 중...",
-    "editLoadingText": "프로필 수정 페이지 불러오는 중..."
+    "editLoadingText": "프로필 수정 페이지 불러오는 중...",
+    "imageUploadError": "이미지 파일만 업로드할 수 있습니다."
   },
   "search": {
     "title": "이사업체 검색",
@@ -621,6 +622,22 @@
     "moverSignupMetadata": {
       "title": "기사님 회원가입 | Moving",
       "description": "기사님 회원가입 페이지입니다."
+    },
+    "error": {
+      "userNotFound": "존재하지 않는 사용자입니다.",
+      "socialLoginOnly": "소셜 로그인 계정입니다. 해당 플랫폼으로 로그인해주세요.",
+      "invalidPassword": "비밀번호가 일치하지 않습니다.",
+      "duplicateEmail": "이미 사용 중인 이메일입니다.",
+      "invalidEmailFormat": "유효하지 않은 이메일 형식입니다.",
+      "nameTooShort": "이름은 최소 2자 이상이어야 합니다.",
+      "passwordTooShort": "비밀번호는 최소 8자 이상이어야 합니다.",
+      "passwordWeak": "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.",
+      "invalidPhoneNumber": "전화번호는 숫자만 입력해야 합니다.",
+      "phoneTooShort": "전화번호는 최소 10자 이상이어야 합니다.",
+      "tokenGeneration": "로그인에 실패했습니다. 잠시 후 다시 시도해주세요.",
+      "userCreationFailed": "회원가입에 실패했습니다. 잠시 후 다시 시도해주세요.",
+      "tokenInvalid": "토큰 인증에 실패했습니다. 다시 로그인해주세요.",
+      "unknown": "알 수 없는 오류가 발생했습니다. 다시 시도해주세요."
     }
   },
   "landing": {

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -386,7 +386,8 @@
       "description": "资料注册页面"
     },
     "registerLoadingText": "正在加载个人资料注册页面...",
-    "editLoadingText": "正在加载个人资料编辑页面..."
+    "editLoadingText": "正在加载个人资料编辑页面...",
+    "imageUploadError": "只能上传图片文件。"
   },
   "search": {
     "title": "搜索搬家公司",
@@ -661,6 +662,22 @@
     "moverSignupMetadata": {
       "title": "搬家师傅注册 | Moving",
       "description": "这是搬家师傅的注册页面。"
+    },
+    "error": {
+      "userNotFound": "用户不存在。",
+      "socialLoginOnly": "这是一个社交登录账户。请使用对应平台登录。",
+      "invalidPassword": "密码不正确。",
+      "duplicateEmail": "该邮箱已被使用。",
+      "invalidEmailFormat": "无效的邮箱格式。",
+      "nameTooShort": "姓名至少需要2个字符。",
+      "passwordTooShort": "密码至少需要8个字符。",
+      "passwordWeak": "密码必须包含字母、数字和特殊字符。",
+      "invalidPhoneNumber": "电话号码只能包含数字。",
+      "phoneTooShort": "电话号码至少需要10位数字。",
+      "tokenGeneration": "登录失败，请稍后再试。",
+      "userCreationFailed": "注册失败，请稍后再试。",
+      "tokenInvalid": "令牌认证失败，请重新登录。",
+      "unknown": "发生未知错误，请重试。"
     }
   },
   "landing": {

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -164,8 +164,13 @@ export default function AuthProvider({ children }: IAuthProviderProps) {
   const logout = async () => {
     try {
       setUser(null);
-      await authApi.logout();
-      window.location.href = `/`;
+      const response = await authApi.logout();
+
+      if (response?.success) {
+        window.location.href = `/`;
+      }
+
+      return response;
     } catch (error) {
       logDevError(error, "Failed to logout");
     } finally {

--- a/src/utils/handleAuthErrorToast.ts
+++ b/src/utils/handleAuthErrorToast.ts
@@ -1,0 +1,28 @@
+// src/utils/handleAuthErrorToast.ts
+"use client";
+
+import { showErrorToast } from "@/utils/toastUtils";
+import { useTranslations } from "next-intl";
+
+type TFunction = ReturnType<typeof useTranslations>;
+
+export const handleAuthErrorToast = (t: TFunction, message: string) => {
+  const errorMap: Record<string, string> = {
+    "존재하지 않는 유저입니다": t("error.userNotFound"),
+    "소셜 로그인 유저입니다. 소셜로그인으로 로그인 해주세요": t("error.socialLoginOnly"),
+    "비밀번호가 일치하지 않습니다": t("error.invalidPassword"),
+    "이미 사용 중인 이메일입니다.": t("error.duplicateEmail"),
+    "유효하지 않은 이메일 형식입니다.": t("error.invalidEmailFormat"),
+    "이름은 최소 2자 이상이어야 합니다.": t("error.nameTooShort"),
+    "비밀번호는 최소 8자 이상이어야 합니다.": t("error.passwordTooShort"),
+    "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.": t("error.passwordWeak"),
+    "전화번호는 숫자만 입력해야 합니다.": t("error.invalidPhoneNumber"),
+    "전화번호는 최소 10자 이상이어야 합니다.": t("error.phoneTooShort"),
+    "토큰 생성 실패로 인한 로그인 실패": t("error.tokenGeneration"),
+    "토큰 생성 실패로 인한 회원가입 실패": t("error.tokenGeneration"),
+    "유저 생성 실패로 인한 회원가입 실패": t("error.userCreationFailed"),
+  };
+
+  const translated = errorMap[message] || t("error.unknown");
+  showErrorToast(translated);
+};


### PR DESCRIPTION
## ✨ 작업 개요
- 로그인 및 회원가입 폼 에러 처리 공통 로직 분리
- 이미지 업로드 시 유효성 검사 추가 (이미지 파일만 업로드 가능)
- 로그인/회원가입쪽 경고/에러 메시지에 대한 번역을 자체 번역으로 변경

## ✅ 주요 작업 내용
- `handleAuthErrorToast` 함수로 중복 로직 통합 및 자체 번역 구현
- `SigninForm`, `SignupForm`에서 switch-case 제거 및 유틸 함수 호출로 변경
- 이미지 업로드 시 MIME 타입 검사 (`image/*`) 적용
- 유효하지 않은 파일 업로드 시 토스트 모달 출력 (`"이미지 파일만 업로드할 수 있습니다"`)


## 📸 스크린샷 (선택)
### 이미지 업로드 토스트 모달
<img width="860" height="605" alt="프로필 등록 이미지 유효성 검사" src="https://github.com/user-attachments/assets/efe269ac-9a21-45ae-8506-aa3cf27db949" />

### 로그인/회원가입 오류 토스트 모달

<img width="993" height="961" alt="로그인 오류 모달 수정" src="https://github.com/user-attachments/assets/4f7fc1d9-95f5-47e7-9718-03101d122974" />
<img width="841" height="911" alt="회원가입 모달 변경" src="https://github.com/user-attachments/assets/d8f12bfa-242f-41e2-acb2-a1c0ded09a86" />


### 로그인/회원가입 오류 토스트 모달 (자체 번역)

<img width="753" height="779" alt="자체 번역 로직 적용" src="https://github.com/user-attachments/assets/899de832-710b-4308-a1a2-333d26ce9a11" />
<img width="694" height="900" alt="회원가입 자체 번역 모달 로직" src="https://github.com/user-attachments/assets/ed084962-2339-4192-ba79-c8f98025ce6f" />


## 🧪 테스트 방법 (선택)
- [x] 회원가입/로그인 시 에러 발생 → 토스트 다국어 메시지 출력 확인
- [x] 이미지 외 파일 업로드 시 `"이미지 파일만 업로드할 수 있습니다"` 토스트 출력 확인

## 📝 비고
- 로그인/회원가입 오류 메시지는 서버에서 받아오는 메시지를 출력중이였음, 이를 서버에서 동적 번역으로 할까 하다가 너무 비효율 적인거 같아서(정적인 데이터) 클라이언트 내부에서 번역 헬퍼 함수를 만들어서 자체 번역 로직을구성함
