### PR TITLE
fix:csrf 도입전으로 롤백

### DIFF
--- a/src/lib/api/user.api.ts
+++ b/src/lib/api/user.api.ts
@@ -92,31 +92,11 @@ const userApi = {
 
   // 기사님 기본 정보 수정
   updateMoverBasicInfo: async (data: IMoverBasicInfoUpdate) => {
-    let csrfToken: string | undefined;
-
-    try {
-      const csrfResponse = await fetch(`${API_URL}/csrf-token`, {
-        method: "GET",
-        headers: {
-          Authorization: `Bearer ${await getAccessToken()}`,
-        },
-        credentials: "include",
-      });
-
-      if (csrfResponse.ok) {
-        const csrfData = await csrfResponse.json();
-        csrfToken = csrfData.data?.token;
-      }
-    } catch (error) {
-      console.error("❌ CSRF 토큰 요청 실패:", error);
-    }
-
     const response = await fetch(`${API_URL}/users/profile/mover/basic`, {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${await getAccessToken()}`,
-        ...(csrfToken && { "X-CSRF-Token": csrfToken }),
       },
       body: JSON.stringify(data),
       credentials: "include",

--- a/src/pageComponents/moverMyPage/edit/EditPage.tsx
+++ b/src/pageComponents/moverMyPage/edit/EditPage.tsx
@@ -12,7 +12,7 @@ import userApi from "@/lib/api/user.api";
 import { useAuth } from "@/providers/AuthProvider";
 import { useValidationRules } from "@/hooks/useValidationRules";
 import { showSuccessToast, showErrorToast } from "@/utils/toastUtils";
-import { handleAuthErrorToast } from "@/utils/handleAuthErrorToast";
+
 
 const EditPage = () => {
   const router = useRouter();
@@ -104,10 +104,9 @@ const EditPage = () => {
           showErrorToast(result.message || t("errorMessage"));
         }
       }
-    } catch (error: any) {
-      console.log("error", error.message);
-      handleAuthErrorToast(t, error.message);
-    }
+          } catch (e) {
+        showErrorToast(t("generalError"));
+      }
   };
 
   return (

--- a/src/pageComponents/profile/edit/MoverEditPage.tsx
+++ b/src/pageComponents/profile/edit/MoverEditPage.tsx
@@ -15,7 +15,7 @@ import { useLocale, useTranslations } from "next-intl";
 import { regionLabelMap } from "@/lib/utils/regionMapping";
 import { getServiceTypeTranslation, getRegionTranslation } from "@/lib/utils/translationUtils";
 import { showSuccessToast, showErrorToast } from "@/utils/toastUtils";
-import { handleAuthErrorToast } from "@/utils/handleAuthErrorToast";
+
 
 const SERVICE_OPTIONS = ["small", "home", "office"];
 const REGION_OPTIONS = [
@@ -196,10 +196,9 @@ export default function MoverEditPage() {
       } else {
         showErrorToast(result.message || t("edit.errorMessage"));
       }
-    } catch (error: any) {
-      console.log("error", error.message);
-      handleAuthErrorToast(t, error.message);
-    }
+          } catch (e) {
+        showErrorToast(t("edit.generalError"));
+      }
   };
 
   return (


### PR DESCRIPTION
## ✨ 작업 개요
- 기사님 프로필 수정 및 기본정보 수정 페이지에서 CSRF 보안 미들웨어 제거
- 프론트엔드 API 호출을 원래 방식으로 되돌림

## ✅ 주요 작업 내용
- API 호출 복원: userApi.updateMoverBasicInfo, userApi.updateMoverProfile을 원래 fetch 방식으로 되돌림

## 🔄 관련 이슈
Closes #이슈번호

## 📸 스크린샷 (선택)
> before / after 비교가 있으면 같이 첨부해주세요

## 🧪 테스트 방법 (선택)
- [ ] 화면 진입 시 데이터 정상 표시

## 📝 비고
- (버그, 추후 개선사항 등)