### PR TITLE
[#234]repactor:견적요청 피드백 반영 및 토스트 알림 색상 변경

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -367,18 +367,18 @@ body {
   font-weight: bold;
 }
 
-/* 성공 토스트 아이콘은 브랜드 오렌지 색상 */
+/* 성공 토스트 아이콘은 초록색 */
 .custom-toast.Toastify__toast--success .Toastify__toast-icon {
-  color: var(--primary-400);
+  color: #28a745;
 }
 
 /* react-toastify 기본 성공 아이콘 오버라이드 */
 .custom-toast.Toastify__toast--success .Toastify__toast-icon svg {
-  fill: var(--primary-400);
+  fill: #28a745;
 }
 
 .custom-toast.Toastify__toast--success .Toastify__toast-icon path {
-  fill: var(--primary-400);
+  fill: #28a745;
 }
 
 /* 에러 토스트 아이콘은 빨간색 */
@@ -391,11 +391,11 @@ body {
   color: #ffc107;
 }
 
-/* 성공 토스트 - 브랜드 오렌지 색상 */
+/* 성공 토스트 - 초록색 */
 .custom-toast.Toastify__toast--success {
-  background: var(--primary-200);
-  color: var(--primary-400);
-  border-left: 4px solid var(--primary-400);
+  background: #d4edda;
+  color: #155724;
+  border-left: 4px solid #28a745;
 }
 
 /* 에러 토스트 - 빨간색으로 구분 */

--- a/src/components/estimateRequest/common/EstimateRequestFlow.tsx
+++ b/src/components/estimateRequest/common/EstimateRequestFlow.tsx
@@ -8,12 +8,14 @@ import { useEstimateRequestForm } from "@/hooks/useEstimateRequestForm";
 import { useEstimateRequestApi } from "@/hooks/useEstimateRequestApi";
 import { useEstimateRequestAddressModal } from "@/hooks/useEstimateRequestAddressModal";
 import MovingTruckLoader from "@/components/common/pending/MovingTruckLoader";
+import { UseQueryResult } from "@tanstack/react-query";
 
 interface EstimateRequestFlowProps {
   title: string;
   onConfirm: (form: any) => void;
   customButtonText?: string;
   showConfirmModal?: (callback: () => void) => void;
+  activeQuery: UseQueryResult<any>;
 }
 
 export const EstimateRequestFlow: React.FC<EstimateRequestFlowProps> = ({
@@ -21,6 +23,7 @@ export const EstimateRequestFlow: React.FC<EstimateRequestFlowProps> = ({
   onConfirm,
   customButtonText,
   showConfirmModal,
+  activeQuery: externalActiveQuery,
 }) => {
   // 공통 훅들 사용
   const formLogic = useEstimateRequestForm();
@@ -42,7 +45,8 @@ export const EstimateRequestFlow: React.FC<EstimateRequestFlowProps> = ({
     locale,
   } = formLogic;
 
-  const { activeQuery } = apiLogic;
+  // 외부에서 전달받은 activeQuery 사용
+  const activeQuery = externalActiveQuery;
 
   // API 로딩 상태 확인
   const isPending = activeQuery.isLoading || activeQuery.isFetching;
@@ -70,19 +74,25 @@ export const EstimateRequestFlow: React.FC<EstimateRequestFlowProps> = ({
   // 로딩 중일 때
   if (isPending) {
     return (
-      <div className="min-h-screen bg-gray-200">
+      <main className="min-h-screen bg-gray-200" role="main" aria-label="견적 요청 로딩 중">
         <MovingTruckLoader size="lg" loadingText={t("estimateRequest.loadingText")} />
-      </div>
+      </main>
     );
   }
 
   return (
     <EstimateRequestLayout title={title} progress={progress}>
-      <section className="fade-in-up" role="region" aria-label="견적 요청 소개">
-        <SpeechBubble type="question">{t("estimateRequest.intro")}</SpeechBubble>
+      <section role="region" aria-label="견적 요청 소개">
+        <SpeechBubble type="question">
+          <span className="sr-only">견적 요청 안내: </span>
+          {t("estimateRequest.intro")}
+        </SpeechBubble>
       </section>
-      <section className="fade-in-up" role="region" aria-label="이사 종류 질문">
-        <SpeechBubble type="question">{t("estimateRequest.movingTypeQuestion")}</SpeechBubble>
+      <section role="region" aria-label="이사 종류 질문">
+        <SpeechBubble type="question">
+          <span className="sr-only">이사 종류 질문: </span>
+          {t("estimateRequest.movingTypeQuestion")}
+        </SpeechBubble>
       </section>
 
       {/* 이전 답변들 */}

--- a/src/components/estimateRequest/common/EstimateRequestLayout.tsx
+++ b/src/components/estimateRequest/common/EstimateRequestLayout.tsx
@@ -30,12 +30,17 @@ export const EstimateRequestLayout: React.FC<IEstimateRequestLayoutProps> = ({ t
               {title}
             </h1>
           </div>
-          <ProgressBar value={progress} aria-labelledby="estimate-request-title" />
+          <ProgressBar value={progress} aria-labelledby="estimate-request-title" aria-label={`진행률 ${progress}%`} />
         </div>
       </header>
 
       {/* 메인 콘텐츠 영역 */}
-      <section className={ESTIMATE_REQUEST_STYLES.content} role="region" aria-labelledby="estimate-request-title">
+      <section
+        className={ESTIMATE_REQUEST_STYLES.content}
+        role="region"
+        aria-labelledby="estimate-request-title"
+        aria-label="견적 요청 콘텐츠"
+      >
         {children}
       </section>
     </main>

--- a/src/components/estimateRequest/create/AddressSearchDaum.tsx
+++ b/src/components/estimateRequest/create/AddressSearchDaum.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { IAddressSearchDaumProps, IDaumAddressData, IDaumPostcodeConstructor } from "@/types/estimateRequest";
 import { useTranslations } from "next-intl";
 
@@ -18,55 +18,181 @@ const ADDRESS_SEARCH_STYLES = {
   description: "text-md text-gray-500",
 } as const;
 
-// Daum 주소 검색 스크립트 로드
-const loadDaumPostcodeScript = () => {
-  if (document.getElementById("daum-postcode-script")) return;
+// Daum 주소 검색 스크립트 로드 (Promise 기반)
+const loadDaumPostcodeScript = (): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    if (document.getElementById("daum-postcode-script")) {
+      // 이미 로드된 경우
+      return resolve();
+    }
 
-  const script = document.createElement("script");
-  script.src = "//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js";
-  script.async = true;
-  script.id = "daum-postcode-script";
-  document.body.appendChild(script);
+    const script = document.createElement("script");
+    script.src = "https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js";
+    script.async = true;
+    script.id = "daum-postcode-script";
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error("Daum postcode script load failed"));
+    document.body.appendChild(script);
+  });
 };
 
 const AddressSearchDaum: React.FC<IAddressSearchDaumProps> = ({ onComplete }) => {
   const t = useTranslations();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [isReady, setIsReady] = useState(false);
+  const embeddedRef = useRef(false);
+  const EMBED_HEIGHT = 420;
+  const [isVisible, setIsVisible] = useState(true);
+  const retryCountRef = useRef(0);
+  const retryTimerRef = useRef<number | null>(null);
+  const ensureTimerRef = useRef<number | null>(null);
+  const postcodePollRef = useRef<number | null>(null);
 
+  // 스크립트 로드 후 임베드 준비
   useEffect(() => {
-    if (!window.daum?.Postcode) {
-      loadDaumPostcodeScript();
+    let isMounted = true;
+    loadDaumPostcodeScript()
+      .then(() => {
+        if (!isMounted) return;
+        setIsReady(true);
+      })
+      .catch(() => {
+        // 로드 실패 시 알림
+        alert(t("addressSearchScriptNotLoaded"));
+      });
+    return () => {
+      isMounted = false;
+    };
+  }, [t]);
+
+  // 준비되면 즉시 임베드 (컨테이너가 레이아웃된 뒤에 수행)
+  useEffect(() => {
+    if (!isReady || !containerRef.current || embeddedRef.current) return;
+
+    const tryEmbed = () => {
+      if (!(window as any).daum?.Postcode) return false;
+      if (!containerRef.current || embeddedRef.current) return;
+      // 컨테이너가 보이지 않으면 표시 후 임베드
+      if (getComputedStyle(containerRef.current).display === "none") {
+        containerRef.current.style.display = "block";
+      }
+      const width = containerRef.current.offsetWidth;
+      const height = containerRef.current.offsetHeight || EMBED_HEIGHT;
+      if (width === 0) return false;
+      containerRef.current.style.height = `${EMBED_HEIGHT}px`;
+
+      const postcode = new (window as any).daum.Postcode({
+        width: "100%",
+        height: EMBED_HEIGHT,
+        maxSuggestItems: 5,
+        oncomplete: function (data: any) {
+          const zoneCode = data.zonecode || "";
+          const roadAddress = data.roadAddress || "";
+          const jibunAddress = data.jibunAddress || "";
+          const bname = data.bname || ""; // 동/읍/면
+
+          onComplete?.({
+            zoneCode,
+            roadAddress,
+            jibunAddress,
+            extraAddress: bname,
+          });
+
+          // 주소 선택 완료 시 임베드 영역 숨김 처리
+          if (containerRef.current) {
+            containerRef.current.style.display = "none";
+            containerRef.current.style.height = "0px";
+            containerRef.current.innerHTML = ""; // iframe 제거
+          }
+          setIsVisible(false);
+        },
+      });
+
+      postcode.embed(containerRef.current!);
+      embeddedRef.current = true;
+
+      // 임베드 후 실제 iframe 렌더가 되었는지 확인, 실패 시 재시도
+      setTimeout(() => {
+        if (!containerRef.current) return;
+        const hasIframe = !!containerRef.current.querySelector("iframe");
+        if (!hasIframe) {
+          embeddedRef.current = false;
+          if (retryCountRef.current < 10) {
+            retryCountRef.current += 1;
+            tryEmbed();
+          }
+        }
+      }, 100);
+
+      // 보강: 주기적으로 iframe 존재 보장 (가끔 부모 리렌더로 사라질 수 있음)
+      if (ensureTimerRef.current) window.clearInterval(ensureTimerRef.current);
+      ensureTimerRef.current = window.setInterval(() => {
+        if (!containerRef.current) return;
+        const hasIframe = !!containerRef.current.querySelector("iframe");
+        if (!hasIframe && isVisible) {
+          embeddedRef.current = false;
+          tryEmbed();
+        }
+      }, 400) as unknown as number;
+      return true;
+    };
+
+    // 0) 라이브러리 로딩 대기 (스크립트 onload 후 Postcode 등록 지연 케이스)
+    if (!(window as any).daum?.Postcode) {
+      postcodePollRef.current = window.setInterval(() => {
+        if ((window as any).daum?.Postcode) {
+          postcodePollRef.current && window.clearInterval(postcodePollRef.current);
+          postcodePollRef.current = null;
+          tryEmbed();
+        }
+      }, 50) as unknown as number;
     }
-  }, []);
 
-  const handleAddressSearch = () => {
-    if (!window.daum?.Postcode) {
-      alert(t("addressSearchScriptNotLoaded"));
-      return;
+    // 1) 즉시 시도
+    if (tryEmbed()) return;
+
+    // 2) 레이아웃이 잡힐 때까지 관찰 후 임베드
+    let ro: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== "undefined") {
+      ro = new ResizeObserver(() => {
+        if (tryEmbed()) {
+          ro && ro.disconnect();
+        }
+      });
+      ro.observe(containerRef.current);
     }
 
-    new window.daum.Postcode({
-      oncomplete: function (data: any) {
-        // 올바른 주소 정보 추출
-        const zoneCode = data.zonecode || "";
-        const roadAddress = data.roadAddress || "";
-        const jibunAddress = data.jibunAddress || "";
-        const bname = data.bname || ""; // 동/읍/면
+    // 3) 안전망: 다음 프레임에 한 번 더 시도
+    const raf = requestAnimationFrame(() => {
+      tryEmbed();
+    });
 
-        onComplete?.({
-          zoneCode: zoneCode,
-          roadAddress: roadAddress,
-          jibunAddress: jibunAddress,
-          extraAddress: bname,
-        });
-      },
-    }).open();
-  };
+    return () => {
+      ro && ro.disconnect();
+      cancelAnimationFrame(raf);
+      if (retryTimerRef.current) {
+        window.clearTimeout(retryTimerRef.current);
+      }
+      if (ensureTimerRef.current) {
+        window.clearInterval(ensureTimerRef.current);
+        ensureTimerRef.current = null;
+      }
+      if (postcodePollRef.current) {
+        window.clearInterval(postcodePollRef.current);
+        postcodePollRef.current = null;
+      }
+    };
+  }, [isReady, onComplete]);
 
   return (
     <div className={ADDRESS_SEARCH_STYLES.container}>
-      <button type="button" onClick={handleAddressSearch} className={ADDRESS_SEARCH_STYLES.button}>
-        {t("estimateRequest.searchAddress")}
-      </button>
+      {isVisible && (
+        <div
+          ref={containerRef}
+          style={{ width: "100%", height: EMBED_HEIGHT, display: "block", overflow: "hidden" }}
+          aria-label={t("estimateRequest.searchAddress")}
+        />
+      )}
       <span className={ADDRESS_SEARCH_STYLES.description}>{t("serviceAvailableCountry")}</span>
     </div>
   );

--- a/src/components/estimateRequest/create/SpeechBubble.tsx
+++ b/src/components/estimateRequest/create/SpeechBubble.tsx
@@ -36,13 +36,14 @@ const SpeechBubble: React.FC<ISpeechBubbleProps> = ({ type, children, isLatest =
         }}
         role={isQuestion ? "region" : "region"}
         aria-label={isQuestion ? "질문 내용" : "답변 내용"}
+        aria-live={isLatest ? "polite" : "off"}
       >
         {children}
       </div>
 
       {/* 수정하기 버튼 - 답변이고 최신이 아니고 수정 함수가 있을 때만 표시 */}
       {isAnswer && !isLatest && onEdit && (
-        <button className={SPEECH_BUBBLE_STYLES.editButton} onClick={onEdit} aria-label={`답변 수정하기`}>
+        <button className={SPEECH_BUBBLE_STYLES.editButton} onClick={onEdit} aria-label={`답변 수정하기`} type="button">
           {t("estimateRequest.editAnswer")}
         </button>
       )}

--- a/src/hooks/useEstimateRequestForm.tsx
+++ b/src/hooks/useEstimateRequestForm.tsx
@@ -4,9 +4,6 @@ import { IFormState, TAddressType, IDaumAddress } from "@/types/estimateRequest"
 import { formatDateByLanguage } from "@/utils/dateUtils";
 import SpeechBubble from "@/components/estimateRequest/create/SpeechBubble";
 
-// 세션 스토리지 키
-const ESTIMATE_REQUEST_SESSION_KEY = "estimateRequest_draft";
-
 // 초기 폼 상태
 const initialForm: IFormState = {
   movingType: "",
@@ -16,48 +13,11 @@ const initialForm: IFormState = {
   arrival: { roadAddress: "", detailAddress: "", zoneCode: "", jibunAddress: "", extraAddress: "" },
 };
 
-// 세션에서 데이터 로드
-const loadFromSession = (): Partial<IFormState> => {
-  if (typeof window === "undefined") return {};
-
-  try {
-    const saved = localStorage.getItem(ESTIMATE_REQUEST_SESSION_KEY);
-    return saved ? JSON.parse(saved) : {};
-  } catch (error) {
-    console.error("세션 데이터 로드 실패:", error);
-    return {};
-  }
-};
-
-// 세션에 데이터 저장
-const saveToSession = (data: IFormState) => {
-  if (typeof window === "undefined") return;
-
-  try {
-    localStorage.setItem(ESTIMATE_REQUEST_SESSION_KEY, JSON.stringify(data));
-  } catch (error) {
-    console.error("세션 데이터 저장 실패:", error);
-  }
-};
-
-// 세션 데이터 삭제
-const clearSession = () => {
-  if (typeof window === "undefined") return;
-
-  try {
-    localStorage.removeItem(ESTIMATE_REQUEST_SESSION_KEY);
-  } catch (error) {
-    console.error("세션 데이터 삭제 실패:", error);
-  }
-};
-
 export const useEstimateRequestForm = (initialData?: Partial<IFormState>) => {
   const [form, setForm] = useState<IFormState>(() => {
-    // 세션에서 복원하거나 초기 데이터 사용
-    const sessionData = loadFromSession();
+    // 초기 데이터만 사용
     return {
       ...initialForm,
-      ...sessionData,
       ...initialData,
     };
   });
@@ -68,11 +28,6 @@ export const useEstimateRequestForm = (initialData?: Partial<IFormState>) => {
   const locale = useLocale();
 
   const progress = step === 4 ? 100 : step * 33;
-
-  // 폼 데이터가 변경될 때마다 세션에 저장
-  useEffect(() => {
-    saveToSession(form);
-  }, [form]);
 
   // 폼 유효성 검사
   const isFormValid = useCallback(() => {
@@ -122,9 +77,8 @@ export const useEstimateRequestForm = (initialData?: Partial<IFormState>) => {
     [setForm],
   );
 
-  // 세션 데이터 초기화
-  const clearSessionData = useCallback(() => {
-    clearSession();
+  // 폼 데이터 초기화
+  const clearFormData = useCallback(() => {
     setForm(initialForm);
     setStep(1);
     setShowNextQuestion(true);
@@ -158,7 +112,7 @@ export const useEstimateRequestForm = (initialData?: Partial<IFormState>) => {
     const answerText = getAnswerText(step, pendingAnswer);
 
     return (
-      <div className="fade-in-up">
+      <div>
         <SpeechBubble type="answer" isLatest={true}>
           {answerText}
         </SpeechBubble>
@@ -172,7 +126,7 @@ export const useEstimateRequestForm = (initialData?: Partial<IFormState>) => {
 
     if (step > 1 && form.movingType) {
       answers.push(
-        <div key="movingType" className="fade-in-up">
+        <div key="movingType">
           <SpeechBubble type="answer" isLatest={false} onEdit={handleEditMovingType}>
             {form.movingType
               ? `${t(`shared.movingTypes.${form.movingType}`)} (${t(`shared.movingTypes.${form.movingType}Desc`)})`
@@ -184,7 +138,7 @@ export const useEstimateRequestForm = (initialData?: Partial<IFormState>) => {
 
     if (step > 2 && form.movingDate) {
       answers.push(
-        <div key="movingDate" className="fade-in-up">
+        <div key="movingDate">
           <SpeechBubble type="answer" isLatest={false} onEdit={handleEditMovingDate}>
             {formatDateByLanguage(form.movingDate, locale as "ko" | "en" | "zh")}
           </SpeechBubble>
@@ -211,7 +165,7 @@ export const useEstimateRequestForm = (initialData?: Partial<IFormState>) => {
     handleDateComplete,
     handleEditStep,
     handleAddressUpdate,
-    clearSessionData,
+    clearFormData,
     getAnswerText,
     handleEditMovingType,
     handleEditMovingDate,

--- a/src/pageComponents/estimateRequest/create/EstimateRequestCreatePage.tsx
+++ b/src/pageComponents/estimateRequest/create/EstimateRequestCreatePage.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { EstimateRequestFlow } from "@/components/estimateRequest/common/EstimateRequestFlow";
-import { useEstimateRequestApi } from "@/hooks/useEstimateRequestApi";
+import { useEstimateRequestApi, useActiveEstimateRequest } from "@/hooks/useEstimateRequestApi";
 import { useTranslations } from "next-intl";
 import MovingTypeSmall from "@/assets/img/etc/smallMoving.webp";
 import MovingTypeHome from "@/assets/img/etc/homeMoving.webp";
@@ -10,6 +10,7 @@ import MovingTypeOffice from "@/assets/img/etc/officeMoving.webp";
 
 const EstimateRequestCreatePage = () => {
   const apiLogic = useEstimateRequestApi();
+  const activeQuery = useActiveEstimateRequest();
   const t = useTranslations();
 
   // 이미지 프리로드
@@ -34,6 +35,7 @@ const EstimateRequestCreatePage = () => {
       title={t("estimateRequest.title")}
       onConfirm={(form) => apiLogic.createMutation.mutate(form)}
       showConfirmModal={apiLogic.showConfirmEstimateRequestModal}
+      activeQuery={activeQuery}
     />
   );
 };

--- a/src/types/estimateRequest.ts
+++ b/src/types/estimateRequest.ts
@@ -149,10 +149,15 @@ export interface IDaumAddressData {
 
 export interface IDaumPostcodeOptions {
   oncomplete: (data: IDaumAddressData) => void;
+  onresize?: (size: { width: number; height: number }) => void;
+  width?: string | number;
+  height?: string | number;
+  maxSuggestItems?: number;
 }
 
 export interface IDaumPostcodeInstance {
   open: () => void;
+  embed: (element: HTMLElement) => void;
 }
 
 export interface IDaumPostcodeConstructor {


### PR DESCRIPTION
## ✨ 작업 개요
- 견적 요청 피드백 반영
- 토스트 알림 색상 변경

## ✅ 주요 작업 내용
- 견적 요청 느리게 올라오는 애니메이션 제거
- 견적 요청 로컬스토리지 저장 제거
- 견적 요청 api 캐싱 고려하여 페이지 접근 시 get 요청 한 번만 보내게
- 견적 요청 카카오 API iframe으로 적용하여 팝업 차단 유저 고려
- 토스트 알림 색상 성공 색상인 초록색으로 변경

## 🔄 관련 이슈
Closes #234

## 📸 스크린샷 (선택)
<img width="1742" height="86" alt="스크린샷 2025-08-08 222240" src="https://github.com/user-attachments/assets/5363c9d6-dde1-46dc-9cb0-64eab3da5993" />
<img width="1256" height="819" alt="스크린샷 2025-08-08 222213" src="https://github.com/user-attachments/assets/ec3ab4ca-83af-4a80-9a7c-ec60bd359694" />
## 🧪 테스트 방법 (선택)
- [ ] 화면 진입 시 데이터 정상 표시

## 📝 비고
- 라이트 하우스 고려 전