### PR TITLE
fix:피드백 반영하여 옵티미스틱 반영, 필요시 다음 페이지 자동로드, 시맨틱 태그 사용, 스크린 리더 고려

### DIFF
--- a/src/components/common/button/Favorite.tsx
+++ b/src/components/common/button/Favorite.tsx
@@ -1,9 +1,6 @@
 import React from "react";
 import { AiOutlineHeart, AiFillHeart } from "react-icons/ai";
 import { useLikeToggle } from "@/hooks/useLikeToggle";
-import { useAuth } from "@/providers/AuthProvider";
-import { useModal } from "@/components/common/modal/ModalContext";
-import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 
 interface IFavoriteProps {
@@ -31,6 +28,7 @@ const Favorite = ({
   onClick,
   disabled = false, // 기본값은 false
 }: IFavoriteProps) => {
+  const t = useTranslations("mover");
   const { isLiked, toggleLike, isLoading } = useLikeToggle({
     moverId: String(moverId),
     initialIsLiked: initialIsFavorited,
@@ -60,6 +58,8 @@ const Favorite = ({
       className={`flex items-center justify-center gap-[2px] ${isLoading ? "opacity-50" : ""} ${disabled ? "cursor-default" : "cursor-pointer"}`}
       onClick={handleFavoriteClick}
       disabled={isLoading || disabled}
+      aria-pressed={isLiked}
+      aria-label={isLiked ? "unfavorite" : "favorite"}
     >
       {heartPosition === "left" ? (
         <>

--- a/src/components/searchMover/MoverCard.tsx
+++ b/src/components/searchMover/MoverCard.tsx
@@ -28,7 +28,7 @@ const MoverCard = ({ mover, variant = "list", showBadge = true, isSelected = fal
   const shouldShowBadge = showBadge && variant === "list";
 
   const renderMobileCard = () => (
-    <div
+    <article
       className={`${variant === "favorite" ? "max-h-[542px]" : "max-h-[250px]"} w-full max-w-[327px] rounded-2xl border-[0.5px] bg-white p-5 ${
         isSelected ? "border-primary-400 bg-primary-50" : "border-[#f2f2f2]"
       }`}
@@ -37,6 +37,9 @@ const MoverCard = ({ mover, variant = "list", showBadge = true, isSelected = fal
           ? "2px 2px 10px 0px #DCDCDC33, -2px -2px 10px 0px #DCDCDC33, 0 0 0 0.5px #F97316"
           : "2px 2px 10px 0px #DCDCDC33, -2px -2px 10px 0px #DCDCDC33",
       }}
+      aria-label={`${mover.nickname || mover.name}`}
+      aria-selected={isSelected}
+      tabIndex={-1}
     >
       <div className="mb-3 flex flex-wrap gap-2 md:mb-3">
         {mover.serviceTypes.map((serviceType, index) => {
@@ -60,7 +63,7 @@ const MoverCard = ({ mover, variant = "list", showBadge = true, isSelected = fal
         <div className="flex gap-2">
           <Image
             src={mover.profileImage || defaultProfileSm}
-            alt="profile-img"
+            alt={`${mover.nickname || mover.name} profile image`}
             width={50}
             height={50}
             className="h-[50px] min-h-[50px] w-[50px] min-w-[50px] flex-shrink-0 rounded-[12px] object-cover"
@@ -68,13 +71,13 @@ const MoverCard = ({ mover, variant = "list", showBadge = true, isSelected = fal
           <div className={`flex flex-col gap-1 ${variant === "favorite" ? "w-[229px]" : ""}`}>
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-1">
-                {shouldShowBadge && <Image src={badge} alt="icon-chat" className="h-[23px] w-5" />}
+                {shouldShowBadge && <Image src={badge} alt="badge" className="h-[23px] w-5" />}
                 <span className="text-[14px] leading-6 font-semibold">
                   {mover.nickname} {t("driverSuffix")}
                 </span>
               </div>
               <div className="flex items-center gap-[7px]">
-                <Image src={like} alt="like-img" className="h-3 w-[14px]" />
+                <Image src={like} alt="favorites" className="h-3 w-[14px]" />
                 <span className="text-[14px] font-normal text-gray-600">{mover.favoriteCount}</span>
               </div>
             </div>
@@ -82,7 +85,7 @@ const MoverCard = ({ mover, variant = "list", showBadge = true, isSelected = fal
               className={`flex items-center ${variant === "favorite" && (mover.experience || 0) >= 10 ? "gap-1.5" : "gap-2"}`}
             >
               <div className="flex items-center gap-0.5">
-                <Image src={star} alt="star-img" className="h-5 w-5" />
+                <Image src={star} alt="rating" className="h-5 w-5" />
                 <span className="text-[13px] leading-[22px] font-medium">
                   {mover.averageRating ? Number(mover.averageRating).toFixed(1) : "0.0"}
                 </span>
@@ -128,11 +131,11 @@ const MoverCard = ({ mover, variant = "list", showBadge = true, isSelected = fal
           </div>
         </div>
       </div>
-    </div>
+    </article>
   );
 
   const renderDesktopCard = () => (
-    <div className="gap-5">
+    <section className="gap-5" aria-label={`${mover.nickname || mover.name}`} aria-selected={isSelected} tabIndex={-1}>
       <div
         className={`w-full rounded-2xl border-[0.5px] bg-white p-5 md:h-[230px] md:max-w-[600px] md:px-6 md:py-7 lg:h-[230px] lg:max-w-[820px] lg:rounded-[20px] ${
           isSelected ? "border-primary-400 bg-primary-50" : "border-[#f2f2f2]"
@@ -154,7 +157,7 @@ const MoverCard = ({ mover, variant = "list", showBadge = true, isSelected = fal
           <div className="flex gap-2 md:gap-5">
             <Image
               src={mover.profileImage || defaultProfile}
-              alt="profile-image"
+              alt={`${mover.nickname || mover.name} profile image`}
               width={134}
               height={134}
               className="h-[134px] min-h-[134px] w-[134px] min-w-[134px] flex-shrink-0 rounded-[12px] object-cover"
@@ -174,7 +177,7 @@ const MoverCard = ({ mover, variant = "list", showBadge = true, isSelected = fal
               </div>
               <div className="flex flex-col gap-1">
                 <div className="flex items-center gap-1">
-                  {shouldShowBadge && <Image src={badge} alt="icon-chat" className="h-[23px] w-5" />}
+                  {shouldShowBadge && <Image src={badge} alt="badge" className="h-[23px] w-5" />}
                   <div className="text-4 leading-[26px] font-semibold">
                     {mover.nickname} {t("driverSuffix")}
                   </div>
@@ -182,7 +185,7 @@ const MoverCard = ({ mover, variant = "list", showBadge = true, isSelected = fal
                 <div className="flex items-center justify-between md:w-[390px] lg:w-[610px]">
                   <div className="flex flex-wrap items-center gap-2">
                     <div className="flex items-center gap-0.5">
-                      <Image src={star} alt="star-img" className="h-5 w-5" />
+                      <Image src={star} alt="rating" className="h-5 w-5" />
                       <span className="text-[13px] leading-[22px] font-medium">
                         {(mover.averageRating || 0).toFixed(1)}
                       </span>
@@ -209,8 +212,8 @@ const MoverCard = ({ mover, variant = "list", showBadge = true, isSelected = fal
                       </span>
                     </div>
                   </div>
-                  <div className="flex items-center gap-0.5">
-                    <Image src={like} alt="like-img" className="h-3 w-[14px]" />
+                  <div className="flex items-center gap-0.5" aria-label="favorites">
+                    <Image src={like} alt="favorites" className="h-3 w-[14px]" />
                     <span className="text-[14px] font-normal text-gray-600">{mover.favoriteCount}</span>
                   </div>
                 </div>
@@ -219,7 +222,7 @@ const MoverCard = ({ mover, variant = "list", showBadge = true, isSelected = fal
           </div>
         </div>
       </div>
-    </div>
+    </section>
   );
 
   const handleCardClick = () => {
@@ -245,14 +248,30 @@ const MoverCard = ({ mover, variant = "list", showBadge = true, isSelected = fal
   // favorite-responsive variant일 때는 클릭으로 선택, 그 외에는 링크로 이동
   if (variant === "favorite-responsive") {
     return (
-      <div className="block cursor-pointer" onClick={handleCardClick}>
+      <div
+        className="block cursor-pointer"
+        onClick={handleCardClick}
+        role="button"
+        tabIndex={0}
+        aria-pressed={isSelected}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            handleCardClick();
+          }
+        }}
+      >
         {cardContent}
       </div>
     );
   }
 
   return (
-    <Link href={`/searchMover/${mover.id}`} className="block">
+    <Link
+      href={`/searchMover/${mover.id}`}
+      className="block focus:outline-none focus-visible:outline-none"
+      aria-label={`View profile of ${mover.nickname || mover.name}`}
+    >
       {cardContent}
     </Link>
   );

--- a/src/hooks/useMoverData.ts
+++ b/src/hooks/useMoverData.ts
@@ -153,6 +153,18 @@ export const useRemoveFavorite = () => {
         if (!oldData) return oldData;
         return { ...oldData, favoriteCount: data.favoriteCount, isFavorited: data.isFavorited };
       });
+
+      // 즐겨찾기 무한 목록에서도 즉시 제거 (옵티미스틱 후속 보장)
+      queryClient.setQueriesData({ queryKey: ["favoriteMovers"] }, (oldData: any) => {
+        if (!oldData?.pages) return oldData;
+        return {
+          ...oldData,
+          pages: oldData.pages.map((page: any) => ({
+            ...page,
+            items: (page.items || []).filter((mover: any) => mover.id !== moverId),
+          })),
+        };
+      });
     },
   });
 };

--- a/src/pageComponents/favoriteMover/FavoriteMoverPage.tsx
+++ b/src/pageComponents/favoriteMover/FavoriteMoverPage.tsx
@@ -9,6 +9,7 @@ import { showSuccessToast, showErrorToast } from "@/utils/toastUtils";
 import MovingTruckLoader from "@/components/common/pending/MovingTruckLoader";
 import { useInfiniteFavoriteMovers } from "@/hooks/useMoverData";
 import { useInView } from "react-intersection-observer";
+import { useQueryClient } from "@tanstack/react-query";
 
 const FavoriteMoverPage = () => {
   const t = useTranslations("favoriteMover");
@@ -17,6 +18,7 @@ const FavoriteMoverPage = () => {
   const [selectedMovers, setSelectedMovers] = useState<Set<string>>(new Set());
   const [selectAll, setSelectAll] = useState(false);
   const [showScrollTop, setShowScrollTop] = useState(false);
+  const queryClient = useQueryClient();
 
   // 무한스크롤을 위한 intersection observer
   const { ref, inView } = useInView();
@@ -41,8 +43,9 @@ const FavoriteMoverPage = () => {
   };
 
   // 무한스크롤 찜한 기사님 조회
+  const FAVORITE_LIMIT = 3;
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError, error } = useInfiniteFavoriteMovers(
-    3,
+    FAVORITE_LIMIT,
     locale,
   ); // 3개씩 가져오기, 언어 파라미터 추가
 
@@ -83,11 +86,34 @@ const FavoriteMoverPage = () => {
   const handleDeleteSelected = async () => {
     if (selectedMovers.size === 0) return;
 
+    // 이전 캐시 스냅샷 (롤백용)
+    let previousInfiniteData: any = null;
+    const deletedCount = selectedMovers.size;
+    const infiniteKey: readonly [string, number, string] = ["favoriteMovers", FAVORITE_LIMIT, locale] as const;
+
     try {
       setDeleting(true);
 
-      // 선택된 기사님들의 찜하기 제거
-      const deletePromises = Array.from(selectedMovers).map((moverId) => findMoverApi.removeFavorite(moverId));
+      // 삭제 대상 ID 목록
+      const idsToRemove = Array.from(selectedMovers);
+
+      // 이전 캐시 스냅샷 저장 (롤백 대비)
+      previousInfiniteData = queryClient.getQueryData(infiniteKey);
+
+      // 옵티미스틱 업데이트: 현재 화면의 무한 스크롤 데이터에서 선택 항목 제거
+      queryClient.setQueryData(infiniteKey, (oldData: any) => {
+        if (!oldData?.pages) return oldData;
+        return {
+          ...oldData,
+          pages: oldData.pages.map((page: any) => ({
+            ...page,
+            items: (page.items || []).filter((mover: IMoverInfo) => !idsToRemove.includes(mover.id.toString())),
+          })),
+        };
+      });
+
+      // 서버에 실제 삭제 요청 병렬 수행
+      const deletePromises = idsToRemove.map((moverId) => findMoverApi.removeFavorite(moverId));
       await Promise.all(deletePromises);
 
       // 선택 상태 초기화
@@ -95,9 +121,28 @@ const FavoriteMoverPage = () => {
       setSelectAll(false);
 
       // 성공 토스트 표시
-      showSuccessToast(`${selectedMovers.size}${t("deleteSuccess")}`);
+      showSuccessToast(`${deletedCount}${t("deleteSuccess")}`);
+
+      // 백그라운드 동기화: 관련 캐시 무효화 (preview 및 다른 한정자 포함)
+      queryClient.invalidateQueries({ queryKey: ["favoriteMovers"] });
+      queryClient.invalidateQueries({ queryKey: ["movers"] });
+
+      // 화면에 최소 FAVORITE_LIMIT 개를 유지하려고 시도 (초기 페이지만 로딩된 경우에 한해 보충)
+      const current = queryClient.getQueryData(infiniteKey) as any;
+      const loadedPages = current?.pages?.length ?? 0;
+      const currentCount = (current?.pages || []).reduce(
+        (sum: number, page: any) => sum + ((page.items || []).length as number),
+        0,
+      );
+      if (loadedPages === 1 && currentCount < FAVORITE_LIMIT && hasNextPage) {
+        await fetchNextPage();
+      }
     } catch (error) {
       console.error("선택된 항목 삭제 실패:", error);
+      // 롤백: 옵티미스틱 업데이트 복구
+      if (previousInfiniteData) {
+        queryClient.setQueryData(infiniteKey, previousInfiniteData as any);
+      }
       // 에러 토스트 표시
       showErrorToast(t("deleteError"));
     } finally {
@@ -125,30 +170,42 @@ const FavoriteMoverPage = () => {
   }
 
   return (
-    <div className="flex min-w-[375px] flex-col">
+    <main className="flex min-w-[375px] flex-col" role="main" aria-label={t("title")}>
       <SectionHeader>
         <div className="flex h-full w-full items-center justify-between px-[30px] md:px-18 lg:px-90">
           <h1 className="text-2lg leading-2lg text-black-500 font-semibold">{t("title")}</h1>
         </div>
       </SectionHeader>
-      <section className="min-h-screen bg-gray-100 pt-[22px]">
-        <div className="mx-auto mb-[10px] flex w-[327px] items-center justify-between md:w-150 lg:w-[814px]">
+      <section className="min-h-screen bg-gray-100 py-[22px]" aria-labelledby="favorite-list-heading">
+        <h2 id="favorite-list-heading" className="sr-only">
+          {t("title")}
+        </h2>
+        <div
+          className="mx-auto mb-[10px] flex w-[327px] items-center justify-between md:w-150 lg:w-[814px]"
+          role="toolbar"
+          aria-label={t("title")}
+        >
           <div className="flex items-center gap-2">
-            <button
-              className={`h-5 w-5 rounded-[4px] border border-gray-200 ${selectAll ? "bg-primary-400" : "bg-gray-50"}`}
-              onClick={handleSelectAll}
+            <input
+              type="checkbox"
+              aria-label={t("selectAll")}
+              className="accent-primary-400 h-5 w-5 rounded-[4px] border border-gray-300 outline-none"
+              checked={selectAll}
+              onChange={handleSelectAll}
             />
-            <span className="text-md text-black-300 leading-6 font-normal md:text-base">
+            <span className="text-md text-black-300 leading-6 font-normal md:text-base" aria-live="polite">
               {t("selectAll")}({selectedMovers.size}/{allFavoriteMovers.length})
             </span>
           </div>
           {selectedMovers.size > 0 && (
-            <span
+            <button
+              type="button"
               className="text-md cursor-pointer leading-6 font-normal text-gray-400 hover:underline md:text-base"
               onClick={handleDeleteSelected}
+              aria-label={deleting ? t("deleting") : t("deleteSelected")}
             >
               {deleting ? t("deleting") : t("deleteSelected")}
-            </span>
+            </button>
           )}
         </div>
 
@@ -162,22 +219,46 @@ const FavoriteMoverPage = () => {
             <p className="text-sm">{t("noFavoritesDesc")}</p>
           </div>
         ) : (
-          <div className="flex flex-col items-center space-y-4">
-            {allFavoriteMovers.map((mover) => (
-              <div key={mover.id} className="relative">
-                <MoverCard
-                  mover={mover}
-                  variant="favorite-responsive"
-                  showBadge={true}
-                  isSelected={selectedMovers.has(mover.id.toString())}
-                  onSelect={handleSelectMover}
-                />
-              </div>
-            ))}
+          <ul
+            className="flex flex-col items-center space-y-4"
+            role="list"
+            aria-busy={isFetchingNextPage || deleting}
+            aria-live="polite"
+          >
+            {allFavoriteMovers.map((mover) => {
+              const isSelected = selectedMovers.has(mover.id.toString());
+              return (
+                <li
+                  key={mover.id}
+                  className="relative flex w-full justify-center focus:outline-none focus-visible:outline-none"
+                  role="listitem"
+                  aria-label={`${mover.nickname || mover.name}`}
+                  aria-selected={isSelected}
+                  tabIndex={0}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      handleSelectMover(mover.id.toString());
+                    }
+                  }}
+                >
+                  <MoverCard
+                    mover={mover}
+                    variant="favorite-responsive"
+                    showBadge={true}
+                    isSelected={isSelected}
+                    onSelect={handleSelectMover}
+                  />
+                  <span className="sr-only" aria-live="polite">
+                    {isSelected ? "selected" : "not selected"}
+                  </span>
+                </li>
+              );
+            })}
 
             {/* 무한스크롤 트리거 */}
             {hasNextPage && (
-              <div ref={ref} className="flex w-full justify-center py-4">
+              <div ref={ref} className="flex w-full justify-center py-4" aria-hidden="true" role="presentation">
                 {isFetchingNextPage ? (
                   <MovingTruckLoader size="md" loadingText={t("loadingMore")} />
                 ) : (
@@ -185,7 +266,7 @@ const FavoriteMoverPage = () => {
                 )}
               </div>
             )}
-          </div>
+          </ul>
         )}
 
         {/* 맨 위로 올라가는 버튼 */}
@@ -207,7 +288,7 @@ const FavoriteMoverPage = () => {
           </button>
         )}
       </section>
-    </div>
+    </main>
   );
 };
 


### PR DESCRIPTION
## ✨ 작업 개요
- 찜한 기사님 페이지에 옵티미스틱 업데이트 반영

## ✅ 주요 작업 내용
- 옵티미스틱 업데이트 반영
- 스크린 리더 고려하여 태그 사용
- 시맨틱 태그로 변경

## 🔄 관련 이슈


## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/a783d92d-5f79-4a94-ada7-c72f1cc90181



## 🧪 테스트 방법 (선택)
- [ ] 화면 진입 시 데이터 정상 표시

## 📝 비고
- 지연님이 피드백 주셨던 무한 스크롤 시 전체 조회가 안되고 삭제 시 그제서야 남은 기사님이 조회되는 문제는 해결하지 못했습니다 