### PR TITLE
refactor : 유저관리 로직 수정

### DIFF
--- a/src/app/[locale]/providers.tsx
+++ b/src/app/[locale]/providers.tsx
@@ -2,15 +2,23 @@ import QueryProvider from "@/providers/QueryProvider";
 import AuthProvider from "@/providers/AuthProvider";
 import { ModalProvider } from "@/components/common/modal/ModalContext";
 import NotificationSSEProvider from "@/providers/NotificationSSEProvider";
+import { HydrationBoundary, type DehydratedState } from "@tanstack/react-query";
 
-const Providers = ({ children }: { children: React.ReactNode }) => {
+interface IProvidersProps {
+  children: React.ReactNode;
+  reactQueryState?: DehydratedState;
+}
+
+const Providers = ({ children, reactQueryState }: IProvidersProps) => {
   return (
     <QueryProvider>
-      <AuthProvider>
-        <ModalProvider>
-          <NotificationSSEProvider>{children}</NotificationSSEProvider>
-        </ModalProvider>
-      </AuthProvider>
+      <HydrationBoundary state={reactQueryState}>
+        <AuthProvider>
+          <ModalProvider>
+            <NotificationSSEProvider>{children}</NotificationSSEProvider>
+          </ModalProvider>
+        </AuthProvider>
+      </HydrationBoundary>
     </QueryProvider>
   );
 };

--- a/src/components/auth/signin/SigninForm.tsx
+++ b/src/components/auth/signin/SigninForm.tsx
@@ -11,6 +11,7 @@ import { useLocale, useTranslations } from "next-intl";
 import { TUserType } from "@/types/user";
 import Link from "next/link";
 import { handleAuthErrorToast } from "@/utils/handleAuthErrorToast";
+import { useRouter } from "next/navigation";
 
 interface ISigninFormProps {
   userType: TUserType;
@@ -18,7 +19,8 @@ interface ISigninFormProps {
 }
 
 const SigninForm = ({ userType, signupLink }: ISigninFormProps) => {
-  const { login, isLoading } = useAuth();
+  const { login, isLoading, getUser } = useAuth();
+  const router = useRouter();
   const validationRules = useValidationRules();
   const t = useTranslations("auth");
   const currentLocale = useLocale();
@@ -45,10 +47,12 @@ const SigninForm = ({ userType, signupLink }: ISigninFormProps) => {
       const response = await login(email, password, userType);
 
       if (response.success) {
+        await getUser();
+
         if (userType === "CUSTOMER") {
-          window.location.href = `/${currentLocale}/searchMover`;
+          router.push(`/${currentLocale}/searchMover`);
         } else {
-          window.location.href = `/${currentLocale}/estimate/received`;
+          router.push(`/${currentLocale}/estimate/received`);
         }
       }
     } catch (error: any) {

--- a/src/components/auth/signup/SignupForm.tsx
+++ b/src/components/auth/signup/SignupForm.tsx
@@ -10,6 +10,7 @@ import { useValidationRules } from "@/hooks/useValidationRules";
 import { useLocale, useTranslations } from "next-intl";
 import { TUserType } from "@/types/user";
 import { handleAuthErrorToast } from "@/utils/handleAuthErrorToast";
+import { useRouter } from "next/navigation";
 
 interface ISignupFormProps {
   userType: TUserType;
@@ -17,7 +18,8 @@ interface ISignupFormProps {
 }
 
 const SignupForm = ({ userType, signinLink }: ISignupFormProps) => {
-  const { signUp, isLoading } = useAuth();
+  const router = useRouter();
+  const { signUp, isLoading, getUser } = useAuth();
   const validationRules = useValidationRules();
   const t = useTranslations("auth");
   const currentLocale = useLocale();
@@ -57,10 +59,12 @@ const SignupForm = ({ userType, signinLink }: ISignupFormProps) => {
       const response = await signUp(signUpData);
 
       if (response.success) {
+        await getUser();
+
         if (userType === "CUSTOMER") {
-          window.location.href = `/${currentLocale}/searchMover`;
+          router.push(`/${currentLocale}/searchMover`);
         } else {
-          window.location.href = `/${currentLocale}/estimate/received`;
+          router.push(`/${currentLocale}/estimate/received`);
         }
       }
     } catch (error: any) {

--- a/src/lib/api/fetcher.api.ts
+++ b/src/lib/api/fetcher.api.ts
@@ -7,14 +7,18 @@ import authApi from "./auth.api";
 // 토큰 만료 시 재발급 로직 구현
 // 요청 api 토큰 인가 실패 -> 리프레쉬 토큰으로 재발급 로직 실행 -> 성공시 이전 요청 재시도
 // 만약 리프레쉬 토큰 만료시 로그아웃 처리
-export const fetchWithAuth = async <T = any>(input: RequestInfo, init: RequestInit = {}, retry = true): Promise<T> => {
+export const fetchWithAuth = async <T = unknown>(
+  input: RequestInfo,
+  init: RequestInit = {},
+  retry = true,
+): Promise<T> => {
   const accessToken = await getTokenFromCookie();
 
   const res = await fetch(input, {
     ...init,
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${accessToken}`,
+      ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
       ...(init.headers || {}),
     },
     credentials: "include", // refreshToken 쿠키 필요 시 포함
@@ -32,7 +36,7 @@ export const fetchWithAuth = async <T = any>(input: RequestInfo, init: RequestIn
           ...init,
           headers: {
             "Content-Type": "application/json",
-            Authorization: `Bearer ${accessToken}`,
+            ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
             ...(init.headers || {}),
           },
         },
@@ -41,7 +45,7 @@ export const fetchWithAuth = async <T = any>(input: RequestInfo, init: RequestIn
     }
   }
 
-  if (res.status === 404) {
+  if (res.status === 401) {
     // 🔒 refreshToken도 만료 → 로그아웃 처리
     authApi.logout();
     throw new Error("로그인이 만료되었습니다.");

--- a/src/lib/api/user.api.ts
+++ b/src/lib/api/user.api.ts
@@ -2,6 +2,11 @@ import { getTokenFromCookie } from "@/utils/auth";
 import { fetchWithAuth } from "./fetcher.api";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL;
+type ApiResponse<T = unknown> = {
+  success: boolean;
+  data?: T;
+  message?: string;
+};
 
 const getAccessToken = async () => {
   return await getTokenFromCookie();
@@ -52,8 +57,8 @@ interface IMoverBasicInfoUpdate {
 
 const userApi = {
   // 사용자 정보 조회
-  getUser: async () => {
-    return fetchWithAuth(`${API_URL}/users`);
+  getUser: async (): Promise<ApiResponse<unknown>> => {
+    return fetchWithAuth<ApiResponse<unknown>>(`${API_URL}/users`);
   },
 
   // 프로필 조회

--- a/src/lib/server/getServerUser.ts
+++ b/src/lib/server/getServerUser.ts
@@ -1,0 +1,36 @@
+"use server";
+
+import { getServerSideToken } from "../actions/auth.actions";
+
+type GetUserApiResponse = {
+  success: boolean;
+  data?: unknown;
+};
+
+export async function getServerUser() {
+  const apiUrl = `${process.env.NEXT_PUBLIC_API_URL}/users`;
+  // SSR: 최초 접속 시 초기 유저 값만 안전하게 가져온다.
+  // 인증 실패(401) 등은 예외를 던지지 않고 null을 반환해 에러 페이지 전파를 방지한다.
+  const accessToken = await getServerSideToken("accessToken");
+  if (!accessToken) return null;
+
+  try {
+    const res = await fetch(apiUrl, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      credentials: "include",
+      cache: "no-store",
+    });
+
+    if (!res.ok) return null;
+    const data: GetUserApiResponse = await res.json();
+    if (!data || data.success === false) return null;
+
+    return (data.data as unknown) ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/src/pageComponents/profile/edit/CustomerEditPage.tsx
+++ b/src/pageComponents/profile/edit/CustomerEditPage.tsx
@@ -101,9 +101,9 @@ export default function CustomerEditPage() {
     try {
       const res = await userApi.updateCustomerBasicInfo(data);
       if (res.success) {
-        showSuccessToast(t("edit.successMessage"));
         await getUser();
         router.push(`/${locale}/searchMover`);
+        showSuccessToast(t("edit.successMessage"));
       }
     } catch (error: any) {
       console.log("error", error.message);

--- a/src/pageComponents/profile/register/CustomerRegisterPage.tsx
+++ b/src/pageComponents/profile/register/CustomerRegisterPage.tsx
@@ -18,8 +18,12 @@ import {
 import { isValidName } from "@/utils/validators";
 import { showSuccessToast } from "@/utils/toastUtils";
 import { handleAuthErrorToast } from "@/utils/handleAuthErrorToast";
+import { useAuth } from "@/providers/AuthProvider";
+import { useRouter } from "next/navigation";
 
 const CustomerRegisterPage = () => {
+  const { getUser } = useAuth();
+  const router = useRouter();
   const validationRules = useValidationRules();
   const t = useTranslations("profile");
   const currentLocale = useLocale();
@@ -53,8 +57,9 @@ const CustomerRegisterPage = () => {
         nickname: data.nickname,
         preferredServices: services,
       });
+      await getUser();
 
-      window.location.href = `/${currentLocale}/searchMover`;
+      router.push(`/${currentLocale}/searchMover`);
       showSuccessToast(t("registerSuccessMessage"));
     } catch (error: any) {
       handleAuthErrorToast(t, error.message);

--- a/src/pageComponents/profile/register/MoverRegisterPage.tsx
+++ b/src/pageComponents/profile/register/MoverRegisterPage.tsx
@@ -18,8 +18,12 @@ import {
 import { isValidName } from "@/utils/validators";
 import { showSuccessToast } from "@/utils/toastUtils";
 import { handleAuthErrorToast } from "@/utils/handleAuthErrorToast";
+import { useAuth } from "@/providers/AuthProvider";
+import { useRouter } from "next/navigation";
 
 const MoverRegisterPage = () => {
+  const { getUser } = useAuth();
+  const router = useRouter();
   const validationRules = useValidationRules();
   const t = useTranslations("profile");
   const currentLocale = useLocale();
@@ -61,10 +65,10 @@ const MoverRegisterPage = () => {
         currentAreas: regions,
         serviceTypes: services,
       };
-
       await userApi.postProfile(profileData);
+      await getUser();
 
-      window.location.href = `/${currentLocale}/estimate/received`;
+      router.push(`/${currentLocale}/estimate/received`);
       showSuccessToast(t("registerSuccessMessage"));
     } catch (error: any) {
       handleAuthErrorToast(t, error.message);


### PR DESCRIPTION
## ✨ 작업 개요
- 기존 CSR 중심(AuthProvider 내부 `useState`/`useEffect`/경로 기반 호출/주기적 `setInterval`)의 유저 관리 로직을 SSR + React Query 기반으로 전환
- 초기 진입 시 SSR에서 유저를 프리패치하여 하이드레이션하고, CSR에서는 이벤트 기반 수동 갱신으로 단순화

## ✅ 주요 작업 내용
- SSR (초기값 시드)
  - `app/[locale]/layout.tsx`: `QueryClient.prefetchQuery(['user'], getServerUser)` + `dehydrate`로 하이드레이션 상태 전달
  - `lib/server/getServerUser.ts`: 최초 접속 시 유저 데이터만 안전하게 조회(401/비정상 응답 시 예외 대신 `null` 반환)

- React Query / AuthProvider
  - `providers/AuthProvider.tsx`:
    - `useQuery(['user'])`를 단일 소스로 통합하고 자동/주기 호출 제거(`enabled: false`, `refetchInterval: false`)
    - 필요 시 명시적으로 `getUser()` 호출(프로필 등록/수정, 역할 전환 등)
    - 토큰 슬라이딩 세션: 고정 주기(14분) 선제 갱신 + 포커스/visibility 복귀 시 즉시 갱신
    - refresh는 single-flight로 중복 방지

- API/인증 보강
  - `lib/api/fetcher.api.ts`:
    - Authorization 헤더 조건부 부착(빈 토큰으로 `Bearer null` 전송 방지)
    - 401 발생 시 `refreshToken()` → 새 토큰으로 원 요청 1회 재시도, 재실패 시 로그아웃 에러 처리
    
- 기대 효과
  - 초기 진입 시 서버에서 유저 하이드레이션 → FCP 시점에 UI 즉시 반영
  - CSR에서는 필요한 순간에만 수동 갱신 → 네트워크 낭비 감소, 깜빡임/이중 로드 완화
  - 인증 흐름(401→refresh→재시도)이 일관되고 안전

## 📝 비고
- 테스트는 진행했지만 혹시 각 기능에서 문제는 없는지 확인 부탁드립니다