### PR TITLE
fix : 미들웨어에서 정적파일은 우회되도록 수정

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -39,10 +39,19 @@ async function getUserFromAccessOrRefreshToken(request: NextRequest) {
 }
 
 export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // 매직 넘버는 상수로 분리
+  const STATIC_PREFIXES = ["/_next", "/static", "/assets", "/img", "/images", "/fonts", "/icons", "/favicon.ico"];
+  const hasFileExt = /\.[a-zA-Z0-9]+$/.test(pathname);
+
+  // 정적/파일 요청은 미들웨어 우회
+  const isStatic = STATIC_PREFIXES.some((p) => pathname.startsWith(p)) || hasFileExt;
+  if (isStatic) return NextResponse.next();
+
+  // ⬇️ 정적 우회 이후에만 i18n 라우팅 적용
   const handleI18nRouting = createMiddleware(routing);
   const response = handleI18nRouting(request);
-
-  const pathname = request.nextUrl.pathname;
 
   // ✅ 루트 경로 접근 처리
   if (pathname === "/") {


### PR DESCRIPTION
## ✨ 작업 개요
- 미들웨어에서 정적 파일 요청 우회 로직 및 matcher 수정  
- 로컬 환경에서 public 폴더 정적 이미지가 차단되는 문제 해결

## ✅ 주요 작업 내용
- `STATIC_PREFIXES` 배열로 정적 파일 경로 정의 (`/img`, `/images`, `/fonts`, `/icons` 등)
- `isStatic` 조건 추가해 정적 파일 요청 시 `NextResponse.next()`로 조기 반환
- `matcher`를 수정해 확장자 있는 모든 파일(`.*\..*`)과 `_next`, `_vercel` 경로 제외
- `.next` 디렉토리 삭제 후 dev 서버 재시작 시 반영 확인
