### PR TITLE
fix:다국어 구조 변경

### DIFF
--- a/src/app/[locale]/review/layout.tsx
+++ b/src/app/[locale]/review/layout.tsx
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 
 import { Tab } from "@/components/common/tab/Tab";
 import { useTranslations } from "next-intl";
@@ -9,7 +9,7 @@ export default function ReviewLayout({
   children: React.ReactNode;
 }>) {
   const t = useTranslations("review");
-  
+
   const tabList = [
     { name: t("writableTab"), href: "/review/writable" },
     { name: t("writtenTab"), href: "/review/written" },

--- a/src/components/common/LanguageInitializer.tsx
+++ b/src/components/common/LanguageInitializer.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { useRouter, usePathname } from "@/i18n/navigation";
 import { useLocale } from "next-intl";
 import { initializeLanguagePreference, syncLanguageSettings } from "@/utils/languageUtils";
 
@@ -10,38 +9,20 @@ interface LanguageInitializerProps {
 }
 
 export function LanguageInitializer({ children }: LanguageInitializerProps) {
-  const router = useRouter();
-  const pathname = usePathname();
   const locale = useLocale();
   const hasInitialized = useRef(false);
 
+  // 앱 최초 1회: 선호 언어 초기화만 수행 (리다이렉트 없음)
   useEffect(() => {
-    // 이미 초기화되었거나 루트 경로인 경우 스킵
-    if (hasInitialized.current || pathname === "/") {
-      return;
-    }
-
-    // 앱이 처음 로드될 때만 언어 설정 초기화
-    const preferredLanguage = initializeLanguagePreference();
-
-    // 현재 경로에서 locale을 추출
-    const currentLocale = pathname.split("/")[1];
-    const validLocales = ["ko", "en", "zh"];
-
-    // 현재 locale이 유효하지 않거나 선호 언어와 다르면 리다이렉트
-    if (!validLocales.includes(currentLocale) || currentLocale !== preferredLanguage) {
-      const newPath = pathname.replace(/^\/(ko|en|zh)/, `/${preferredLanguage}`);
-      router.replace(newPath);
-    }
-
+    if (hasInitialized.current) return;
+    initializeLanguagePreference();
     hasInitialized.current = true;
-  }, []); // 의존성 배열을 비워서 한 번만 실행
+  }, []);
 
-  // 현재 locale이 변경될 때마다 언어 설정 동기화
+  // 로케일 변화 시 저장소/쿠키 동기화만 수행
   useEffect(() => {
-    if (hasInitialized.current) {
-      syncLanguageSettings();
-    }
+    if (!hasInitialized.current) return;
+    syncLanguageSettings();
   }, [locale]);
 
   return <>{children}</>;

--- a/src/hooks/useEstimateRequestForm.tsx
+++ b/src/hooks/useEstimateRequestForm.tsx
@@ -29,6 +29,17 @@ export const useEstimateRequestForm = (initialData?: Partial<IFormState>) => {
 
   const progress = step === 4 ? 100 : step * 33;
 
+  // 과거에 사용하던 견적요청 드래프트 로컬스토리지 키를 더 이상 사용하지 않도록 초기화 시 제거
+  useEffect(() => {
+    try {
+      if (typeof window !== "undefined") {
+        localStorage.removeItem("estimateRequest_draft");
+      }
+    } catch {
+      // ignore
+    }
+  }, []);
+
   // 폼 유효성 검사
   const isFormValid = useCallback(() => {
     return !!(form.movingType && form.movingDate && form.departure.roadAddress && form.arrival.roadAddress);

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,23 +1,17 @@
+// src/i18n/request.ts
 import { getRequestConfig } from "next-intl/server";
 import { hasLocale } from "next-intl";
 import { routing } from "./routing";
-import en from "../messages/en.json";
-import ko from "../messages/ko.json";
-import zh from "../messages/zh.json";
-
-const messagesMap = {
-  en,
-  ko,
-  zh,
-};
 
 export default getRequestConfig(async ({ requestLocale }) => {
-  // 일반적으로 `[locale]` 세그먼트에 해당
   const requested = await requestLocale;
   const locale = hasLocale(routing.locales, requested) ? requested : routing.defaultLocale;
 
+  // 핵심: 필요한 로케일만 동적 import
+  const messages = (await import(`../messages/${locale}.json`)).default;
+
   return {
     locale,
-    messages: messagesMap[locale as keyof typeof messagesMap],
+    messages,
   };
 });

--- a/src/pageComponents/profile/edit/CustomerEditPage.tsx
+++ b/src/pageComponents/profile/edit/CustomerEditPage.tsx
@@ -8,7 +8,7 @@ import userApi, { TUserProfile, TApiResponse } from "@/lib/api/user.api";
 const uploadSkeleton: { src: string } = { src: "/img/etc/profile-upload-skeleton.webp" };
 import { useRouter } from "next/navigation";
 import { useValidationRules } from "@/hooks/useValidationRules";
-import { useLocale, useTranslations } from "use-intl";
+import { useLocale, useTranslations } from "next-intl";
 import {
   ProfileEditHeader,
   ProfileEditImageUpload,

--- a/src/pageComponents/profile/register/CustomerRegisterPage.tsx
+++ b/src/pageComponents/profile/register/CustomerRegisterPage.tsx
@@ -7,7 +7,7 @@ const uploadSkeleton: { src: string } = { src: "/img/etc/profile-upload-skeleton
 
 import userApi from "@/lib/api/user.api";
 import { useValidationRules } from "@/hooks/useValidationRules";
-import { useLocale, useTranslations } from "use-intl";
+import { useLocale, useTranslations } from "next-intl";
 import {
   ProfileFormHeader,
   ProfileImageUpload,


### PR DESCRIPTION
✨ 작업 개요
다국어 구조 변경
✅ 주요 작업 내용
`src/i18n/request.ts`: 모듈 상단의 `en.json`, `ko.json`, `zh.json` 일괄 import 제거
- 요청된 로케일만 동적 import로 로드: `const messages = (await import(...)).default`
- 효과: 서버 번들/파싱 및 직렬화 비용 감소, 초기 로드/TTFB 개선
`src/components/common/LanguageInitializer.tsx`
- 클라이언트 측 자동 리다이렉트 제거
- 최초 진입 시 선호 언어 저장만 수행, 로케일 변경 시 설정 동기화만 유지
- 효과: SSR 이후 클라 더블 네비게이션/깜빡임 제거
`src/middleware.ts`
- 경로 매칭 단순화: "/"와 "/:path*"만 매치 후 내부에서 직접 분기
- 정적/파일 요청은 즉시 우회 유지
- 비로케일 경로는 서버에서 선호 로케일로 SSR 리다이렉트(/{preferredLocale}${pathname})
- 로케일 경로(예: /{locale}/...)에서만 보호/인증 분기 수행
- 효과: i18n-only 이동에서 엣지 미들웨어/토큰 처리 오버헤드 최소화, 404 오매칭 문제 해소
`src/pageComponents/profile/register/CustomerRegisterPage.tsx`, `src/pageComponents/profile/edit/CustomerEditPage.tsx`
- use-intl → next-intl로 임포트 통일
- 효과: 컨텍스트/번들 혼용 제거

🔄 관련 이슈

📸 스크린샷 (선택)
> before / after 비교가 있으면 같이 첨부해주세요

🧪 테스트 방법 (선택)
[ ] / 진입 시 /{preferredLocale}로 SSR 리다이렉트되는지 확인
[ ] /userSignin 등 비로케일 경로 진입 시 /{preferredLocale}/userSignin으로 SSR 리다이렉트되는지 확인
[ ] /{locale} 랜딩 페이지는 보호 예외로 정상 진입되는지 확인
[ ] 공개 로케일 경로(예: /{locale}/searchMover)는 404 없이 정상 진입되는지 확인
[ ] 보호/인증 경로 접근 시 토큰 유무/역할에 따라 기존 분기 로직이 정상 동작하는지 확인
[ ] 언어 스위처로 로케일 변경 시 깜빡임/추가 네비 없이 전환되는지 확인
📝 비고
미들웨어에서 next-intl 미들웨어 의존을 제거하고 수동 분기로 단순화했습니다. 필요 시 불필요 import 정리 가능.
추가 성능 개선 여지:
루트 Provider에는 common, shared 등 최소 네임스페이스만 주입하고, 페이지/하위 레이아웃에서 필요한 네임스페이스만 추가 주입
메시지 파일을 도메인별로 분할해 필요한 조합만 로드/직렬화
핵심 변경 요약
메시지 로딩: 동적 import로 전환
클라 리다이렉트: 제거
미들웨어: matcher 단순화 + 내부 분기, 비로케일 → 선호 로케일 SSR 리다이렉트
라이브러리 혼용: next-intl로 일원화