### PR TITLE
fix: 견적 요청 QA 피드백 적용

### DIFF
--- a/src/components/estimateRequest/(my)/MoverInfo.tsx
+++ b/src/components/estimateRequest/(my)/MoverInfo.tsx
@@ -52,6 +52,8 @@ export const MoverInfo = ({ mover, usedAt, estimateId, hasConfirmedEstimate }: I
       // 캐시 무효화하여 데이터 새로고침
       queryClient.invalidateQueries({ queryKey: ["pendingEstimateRequests", locale] });
       queryClient.invalidateQueries({ queryKey: ["receivedEstimateRequests", locale] });
+      // 활성 견적요청(hasEstimate 포함)도 즉시 최신화
+      queryClient.invalidateQueries({ queryKey: ["estimateRequest", "active", locale] });
       // 기사님 관련 페이지 캐시 무효화
       queryClient.invalidateQueries({ queryKey: ["MyRequestEstimates"] });
       queryClient.invalidateQueries({ queryKey: ["MyRejectedEstimates"] });

--- a/src/components/estimateRequest/common/EstimateRequestStepRenderer.tsx
+++ b/src/components/estimateRequest/common/EstimateRequestStepRenderer.tsx
@@ -40,14 +40,18 @@ export const EstimateRequestStepRenderer: React.FC<IEstimateRequestStepRendererP
       case 1:
         return (
           // LCP 구간: 초기 페인트 지연 방지를 위해 애니메이션 제거
-          <section role="region" aria-label="이사 종류 선택">
+          <section role="region" aria-label={t("estimateRequest.aria.selectMovingTypeSection")}>
             <MovingTypeSection value={form.movingType} onSelect={onSelectMovingType} />
           </section>
         );
       // case 2: 이사 날짜 선택 화면
       case 2:
         return (
-          <section className="animate-fade-in-up" role="region" aria-label="이사 날짜 선택">
+          <section
+            className="animate-fade-in-up"
+            role="region"
+            aria-label={t("estimateRequest.aria.selectDateSection")}
+          >
             <SpeechBubble type="question">{t("estimateRequest.dateQuestion")}</SpeechBubble>
             <SpeechBubble type="question">
               <DateSection
@@ -62,7 +66,11 @@ export const EstimateRequestStepRenderer: React.FC<IEstimateRequestStepRendererP
       // case 3: 출발지/도착지 주소 입력 화면
       case 3:
         return (
-          <section className="animate-fade-in-up" role="region" aria-label="주소 입력">
+          <section
+            className="animate-fade-in-up"
+            role="region"
+            aria-label={t("estimateRequest.aria.addressInputSection")}
+          >
             <SpeechBubble type="question">{t("estimateRequest.addressQuestion")}</SpeechBubble>
             <SpeechBubble type="question">
               <div className={ESTIMATE_REQUEST_STYLES.addressContainer}>
@@ -102,9 +110,17 @@ export const EstimateRequestStepRenderer: React.FC<IEstimateRequestStepRendererP
       // case 4: 입력한 모든 정보를 요약해서 보여주고, 최종 확인(요청) 버튼을 제공하는 화면
       case 4:
         return (
-          <section className="animate-fade-in-up" role="region" aria-label="견적 요청 정보 확인">
+          <section
+            className="animate-fade-in-up"
+            role="region"
+            aria-label={t("estimateRequest.aria.confirmInfoSection")}
+          >
             <SpeechBubble type="answer" isLatest={true}>
-              <div className={ESTIMATE_REQUEST_STYLES.resultContainer} role="list" aria-label="견적 요청 정보 목록">
+              <div
+                className={ESTIMATE_REQUEST_STYLES.resultContainer}
+                role="list"
+                aria-label={t("estimateRequest.aria.infoList")}
+              >
                 <div className={ESTIMATE_REQUEST_STYLES.resultItem} role="listitem">
                   {t("estimateRequest.result.movingType")}:{" "}
                   {form.movingType

--- a/src/components/estimateRequest/create/sections/MovingTypeSection.tsx
+++ b/src/components/estimateRequest/create/sections/MovingTypeSection.tsx
@@ -57,8 +57,7 @@ const MovingTypeSection: React.FC<IMovingTypeSectionProps> = ({ value, onSelect 
                   <Image
                     src={image}
                     alt={t(`shared.movingTypes.${type}`)}
-                    width={120}
-                    height={120}
+                    fill
                     sizes="(min-width: 1024px) 120px, 96px"
                     decoding="sync"
                     className="object-contain"

--- a/src/constant/estimateRequestStyles.ts
+++ b/src/constant/estimateRequestStyles.ts
@@ -3,7 +3,7 @@
 export const ESTIMATE_REQUEST_CARD_STYLES = {
   // MovingTypeCard 스타일
   movingType: {
-    base: "w-full rounded-2xl border flex flex-row items-center gap-4 px-4 py-5 transition-colors duration-200 lg:px-6 lg:py-6",
+    base: "w-full rounded-2xl border flex flex-row items-center gap-4 px-4 py-5 transition-colors duration-200 lg:px-6 lg:py-6 cursor-pointer",
     selected: "border-primary-400 bg-primary-50",
     unselected: "border-gray-200 bg-white",
     radioBase: "inline-block h-6 w-6 items-center justify-center rounded-full border-[1px] transition-colors",
@@ -14,6 +14,7 @@ export const ESTIMATE_REQUEST_CARD_STYLES = {
     textArea: "text-left",
     title: "text-black-500 text-base leading-[26px] font-semibold",
     description: "text-[14px] leading-6 font-normal text-gray-500",
+    // 이미지 수직 정렬 보정: 모두 중앙 정렬로 통일
     imageContainer: "flex w-1/3 items-center justify-end",
   },
 

--- a/src/hooks/useEstimateRequestForm.tsx
+++ b/src/hooks/useEstimateRequestForm.tsx
@@ -29,6 +29,14 @@ export const useEstimateRequestForm = (initialData?: Partial<IFormState>) => {
 
   const progress = step === 4 ? 100 : step * 33;
 
+  // 변경 여부(dirty) 판단
+  const isDirty = React.useMemo(() => {
+    const hasMoving = !!form.movingType || !!form.movingDate;
+    const hasDeparture = !!form.departure.roadAddress || !!form.departure.detailAddress;
+    const hasArrival = !!form.arrival.roadAddress || !!form.arrival.detailAddress;
+    return hasMoving || hasDeparture || hasArrival;
+  }, [form]);
+
   // 과거에 사용하던 견적요청 드래프트 로컬스토리지 키를 더 이상 사용하지 않도록 초기화 시 제거
   useEffect(() => {
     try {
@@ -170,6 +178,7 @@ export const useEstimateRequestForm = (initialData?: Partial<IFormState>) => {
     pendingAnswer,
     setPendingAnswer,
     progress,
+    isDirty,
     isFormValid,
     handleSelectMovingType,
     handleDateChange,

--- a/src/hooks/useUnsavedChangesGuard.tsx
+++ b/src/hooks/useUnsavedChangesGuard.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import React, { useEffect, useRef, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { useModal } from "@/components/common/modal/ModalContext";
+import { useTranslations } from "next-intl";
+
+export const useUnsavedChangesGuard = (isDirty: boolean) => {
+  const t = useTranslations("common");
+  const router = useRouter();
+  const { open, close } = useModal();
+  const bypassRef = useRef(false);
+  const pendingHrefRef = useRef<string | null>(null);
+  const isHandlingPopstateRef = useRef(false);
+
+  const bypassNextNavigation = useCallback(() => {
+    bypassRef.current = true;
+    setTimeout(() => {
+      bypassRef.current = false;
+    }, 0);
+  }, []);
+
+  // 일정 시간 동안 새로고침 경고를 비활성화
+  const bypassFor = useCallback((durationMs: number = 2000) => {
+    bypassRef.current = true;
+    setTimeout(
+      () => {
+        bypassRef.current = false;
+      },
+      Math.max(0, durationMs),
+    );
+  }, []);
+
+  const confirmNavigate = useCallback(
+    (onConfirm: () => void) => {
+      open({
+        title: t("unsaved.leaveConfirmTitle"),
+        children: (
+          <div className="">
+            <p className="mb-2 text-gray-700">{t("unsaved.leaveConfirmMessage1")}</p>
+            <p className="text-gray-700">{t("unsaved.leaveConfirmMessage2")}</p>
+          </div>
+        ),
+        buttons: [
+          {
+            variant: "outlined" as const,
+            text: t("cancel"),
+            onClick: () => close(),
+          },
+          {
+            text: t("unsaved.leave"),
+            onClick: () => {
+              close();
+              bypassRef.current = true;
+              onConfirm();
+              // reset bypass in next tick
+              setTimeout(() => {
+                bypassRef.current = false;
+              }, 0);
+            },
+          },
+        ],
+      });
+    },
+    [open, close],
+  );
+
+  // Warn on browser unload/refresh
+  useEffect(() => {
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (!isDirty || bypassRef.current) return;
+      e.preventDefault();
+      e.returnValue = "";
+      return "";
+    };
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
+  }, [isDirty]);
+
+  // Intercept anchor navigations
+  useEffect(() => {
+    const onDocClick = (e: MouseEvent) => {
+      if (!isDirty || bypassRef.current) return;
+      const targetEl = (e.target as Element)?.closest<HTMLAnchorElement>("a[href]");
+      if (!targetEl) return;
+      // Ignore hash/mailto/tel/explicit opt-out
+      const href = targetEl.getAttribute("href") || "";
+      if (!href || href.startsWith("#") || href.startsWith("mailto:") || href.startsWith("tel:")) return;
+      if ((targetEl as HTMLElement).dataset.ignoreUnsaved === "true") return;
+
+      e.preventDefault();
+      pendingHrefRef.current = href;
+      confirmNavigate(() => {
+        const next = pendingHrefRef.current;
+        pendingHrefRef.current = null;
+        if (next) router.push(next);
+      });
+    };
+    document.addEventListener("click", onDocClick, { capture: true });
+    return () => document.removeEventListener("click", onDocClick, { capture: true } as any);
+  }, [isDirty, confirmNavigate, router]);
+
+  // Intercept keyboard refresh (F5, Ctrl/Cmd+R) to bypass prompt and reload immediately
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!isDirty) return;
+      const key = e.key?.toLowerCase();
+      const isF5 = e.key === "F5";
+      const isCtrlOrCmdR = key === "r" && (e.ctrlKey || e.metaKey);
+      if (isF5 || isCtrlOrCmdR) {
+        e.preventDefault();
+        bypassRef.current = true;
+        // Immediate hard reload without native prompt
+        window.location.reload();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown, { capture: true });
+    return () => window.removeEventListener("keydown", onKeyDown, { capture: true } as any);
+  }, [isDirty]);
+
+  // Intercept browser back/forward (popstate)
+  useEffect(() => {
+    // push a state so first back triggers popstate
+    const push = () => {
+      try {
+        window.history.pushState({ guard: true }, "", window.location.href);
+      } catch {
+        // ignore
+      }
+    };
+    push();
+
+    const onPopState = (e: PopStateEvent) => {
+      if (isHandlingPopstateRef.current) return;
+      if (!isDirty || bypassRef.current) return;
+      e.preventDefault();
+      // Immediately push state back to cancel the back navigation
+      isHandlingPopstateRef.current = true;
+      push();
+      confirmNavigate(() => {
+        // allow one back
+        bypassRef.current = true;
+        window.history.back();
+        setTimeout(() => {
+          bypassRef.current = false;
+        }, 0);
+      });
+      setTimeout(() => {
+        isHandlingPopstateRef.current = false;
+      }, 0);
+    };
+
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, [isDirty, confirmNavigate]);
+
+  return { bypassNextNavigation, bypassFor };
+};

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -19,7 +19,13 @@
     "completeSelection": "Complete Selection",
     "editAnswer": "Edit",
     "success": "Success",
-    "retry": "Retry"
+    "retry": "Retry",
+    "unsaved": {
+      "leaveConfirmTitle": "Leave Confirm",
+      "leaveConfirmMessage1": "You have unsaved changes.",
+      "leaveConfirmMessage2": "Are you sure you want to leave this page?",
+      "leave": "Leave"
+    }
   },
   "shared": {
     "units": {
@@ -323,6 +329,14 @@
     "openDropdown": "Open Dropdown",
     "estimateRequestAndEstimates": "Estimate Request and Estimates",
     "aria": {
+      "main": "Estimate request page",
+      "progress": "Progress",
+      "content": "Estimate request content",
+      "question": "Question bubble",
+      "answer": "Answer bubble",
+      "questionContent": "Question content",
+      "answerContent": "Answer content",
+      "editAnswer": "Edit answer",
       "mainContent": "Pending estimate request page",
       "estimateRequestSection": "Estimate request information section",
       "estimateListSection": "Estimate list section",
@@ -365,6 +379,13 @@
       "departureLabel": "Departure label",
       "arrivalLabel": "Arrival label",
       "movingDateLabel": "Moving date label",
+      "introSection": "Estimate request introduction",
+      "movingTypeQuestionSection": "Moving type question",
+      "selectMovingTypeSection": "Select moving type",
+      "selectDateSection": "Select moving date",
+      "addressInputSection": "Address input",
+      "confirmInfoSection": "Review estimate request info",
+      "infoList": "Estimate request info list",
       "detailPageContent": "Estimate request detail page content",
       "detailPageLoadingSection": "Detail page loading section",
       "detailPageErrorSection": "Detail page error section",
@@ -559,6 +580,14 @@
     "all": "All",
     "requestDateShort": "Request date",
     "aria": {
+      "main": "Estimate request page",
+      "progress": "Progress",
+      "content": "Estimate request content",
+      "question": "Question bubble",
+      "answer": "Answer bubble",
+      "questionContent": "Question content",
+      "answerContent": "Answer content",
+      "editAnswer": "Edit answer",
       "mainContent": "Pending estimate request page",
       "estimateRequestSection": "Estimate request information section",
       "estimateListSection": "Estimate list section",

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -17,7 +17,13 @@
     "next": "다음",
     "previous": "이전",
     "success": "완료",
-    "retry": "다시 시도"
+    "retry": "다시 시도",
+    "unsaved": {
+      "leaveConfirmTitle": "이동 확인",
+      "leaveConfirmMessage1": "작성 중인 내용이 사라질 수 있어요.",
+      "leaveConfirmMessage2": "페이지를 이동하시겠습니까?",
+      "leave": "이동"
+    }
   },
   "shared": {
     "units": {
@@ -152,6 +158,14 @@
     "all": "전체",
     "requestDateShort": "견적 요청일",
     "aria": {
+      "main": "견적 요청 페이지",
+      "progress": "진행률",
+      "content": "견적 요청 콘텐츠",
+      "question": "질문 말풍선",
+      "answer": "답변 말풍선",
+      "questionContent": "질문 내용",
+      "answerContent": "답변 내용",
+      "editAnswer": "답변 수정하기",
       "mainContent": "진행중인 견적 요청 페이지",
       "estimateRequestSection": "견적 요청 정보 섹션",
       "estimateListSection": "견적 목록 섹션",
@@ -194,6 +208,13 @@
       "departureLabel": "출발지 라벨",
       "arrivalLabel": "도착지 라벨",
       "movingDateLabel": "이사날짜 라벨",
+      "introSection": "견적 요청 소개",
+      "movingTypeQuestionSection": "이사 종류 질문",
+      "selectMovingTypeSection": "이사 종류 선택",
+      "selectDateSection": "이사 날짜 선택",
+      "addressInputSection": "주소 입력",
+      "confirmInfoSection": "견적 요청 정보 확인",
+      "infoList": "견적 요청 정보 목록",
       "detailPageContent": "견적 요청 상세 페이지 콘텐츠",
       "detailPageLoadingSection": "상세 페이지 로딩 섹션",
       "detailPageErrorSection": "상세 페이지 오류 섹션",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -19,7 +19,13 @@
     "completeSelection": "完成选择",
     "editAnswer": "修改",
     "success": "完成",
-    "retry": "重试"
+    "retry": "重试",
+    "unsaved": {
+      "leaveConfirmTitle": "离开确认",
+      "leaveConfirmMessage1": "您有未保存的更改。",
+      "leaveConfirmMessage2": "您确定要离开此页面吗？",
+      "leave": "离开"
+    }
   },
   "shared": {
     "units": {
@@ -154,6 +160,14 @@
     "all": "全部",
     "requestDateShort": "申请日期",
     "aria": {
+      "main": "报价请求页面",
+      "progress": "进度",
+      "content": "报价请求内容",
+      "question": "问题气泡",
+      "answer": "回答气泡",
+      "questionContent": "问题内容",
+      "answerContent": "回答内容",
+      "editAnswer": "修改回答",
       "mainContent": "待处理报价请求页面",
       "estimateRequestSection": "报价请求信息部分",
       "estimateListSection": "报价列表部分",
@@ -196,6 +210,13 @@
       "departureLabel": "出发地标签",
       "arrivalLabel": "目的地标签",
       "movingDateLabel": "搬家日期标签",
+      "introSection": "报价请求介绍",
+      "movingTypeQuestionSection": "搬家类型问题",
+      "selectMovingTypeSection": "选择搬家类型",
+      "selectDateSection": "选择搬家日期",
+      "addressInputSection": "地址输入",
+      "confirmInfoSection": "确认报价请求信息",
+      "infoList": "报价请求信息列表",
       "detailPageContent": "报价请求详情页面内容",
       "detailPageLoadingSection": "详情页面加载部分",
       "detailPageErrorSection": "详情页面错误部分",

--- a/src/pageComponents/estimateRequest/create/EstimateRequestCreatePage.tsx
+++ b/src/pageComponents/estimateRequest/create/EstimateRequestCreatePage.tsx
@@ -20,6 +20,7 @@ const EstimateRequestCreatePage = () => {
       title={t("estimateRequest.title")}
       onConfirm={(form) => apiLogic.createMutation.mutate(form)}
       showConfirmModal={apiLogic.showConfirmEstimateRequestModal}
+      enableUnsavedGuard={true}
     />
   );
 };

--- a/src/pageComponents/estimateRequest/edit/EstimateRequestEditPage.tsx
+++ b/src/pageComponents/estimateRequest/edit/EstimateRequestEditPage.tsx
@@ -9,11 +9,7 @@ import { useEstimateRequestForm } from "@/hooks/useEstimateRequestForm";
 import { useEstimateRequestApi, useActiveEstimateRequest } from "@/hooks/useEstimateRequestApi";
 import { useTranslations, useLocale } from "next-intl";
 import { formatDateByLanguage } from "@/utils/dateUtils";
-import { estimateRequestClientApi } from "@/lib/api/estimateRequest.client";
 import { IEstimateRequestResponse } from "@/types/estimateRequest";
-import { logDevError } from "@/utils/logDevError";
-import * as Sentry from "@sentry/nextjs";
-
 import { EstimateRequestFlow } from "@/components/estimateRequest/common/EstimateRequestFlow";
 
 const EstimateRequestEditPage = () => {


### PR DESCRIPTION
## ✨ 작업 개요
- 견적 요청 QA 피드백 적용

## ✅ 주요 작업 내용
- 일반 유저가 기사님이 보낸 견적서를 반려 했을 때 캐싱으로 견적서가 남아 있어서 분기가 되었던 문제 해결
- 아리아 문법 번역 부족한 부분 추가 및 에러 해결
- 이동 방지 훅 적용
- 
## 🔄 관련 이슈

## 📸 스크린샷 (선택)

## 🧪 테스트 방법 (선택)
- [ ] 화면 진입 시 데이터 정상 표시
- 정상 동작 확인
- 
## 📝 비고
- 기사님 견적서 수락 시 다시 견적 요청을 보낼 수 있지만 마지막 요청을 백엔드로 보내기 전에 모달로 진행중인 견적이 있다고 보여주기 때문에 문제 없을 듯 