### PR TITLE
Fix: QA 피드백 사항 수정

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -882,6 +882,7 @@
       "errorTitle": "Profile Update Failed",
       "errorMessage": "Failed to update profile.",
       "generalError": "An error occurred.",
+      "loadingText": "Loading profile edit page...",
       "confirm": "Confirm",
 
       "optional": "(Optional)"
@@ -1029,7 +1030,8 @@
       "reviews": "Reviews",
       "totalExperience": "Career",
       "providedServices": "Provided Services",
-      "serviceAreas": "Service Areas"
+      "serviceAreas": "Service Areas",
+      "loadingText": "Loading mover my page..."
     },
     "aria": {
       "searchResults": "{count} movers found",
@@ -1105,7 +1107,8 @@
     "save": "Save Changes",
     "successMessage": "Profile updated successfully.",
     "errorMessage": "Update failed.",
-    "generalError": "An error occurred."
+    "generalError": "An error occurred.",
+    "loadingText": "Loading basic info edit page..."
   },
   "auth": {
     "signin": "Sign In",

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -841,6 +841,7 @@
       "errorTitle": "프로필 수정 실패",
       "errorMessage": "수정에 실패했습니다.",
       "generalError": "오류가 발생했습니다.",
+      "loadingText": "프로필 수정 페이지 불러오는 중...",
       "confirm": "확인",
       "name": "이름",
       "namePlaceholder": "이름을 입력해 주세요",
@@ -998,7 +999,8 @@
       "reviews": "리뷰",
       "totalExperience": "총 경력",
       "providedServices": "제공 서비스",
-      "serviceAreas": "서비스 가능 지역"
+      "serviceAreas": "서비스 가능 지역",
+      "loadingText": "기사님 마이페이지 불러오는 중..."
     },
     "aria": {
       "searchResults": "검색된 기사님 {count}명",
@@ -1074,7 +1076,8 @@
     "save": "수정하기",
     "successMessage": "기본정보가 성공적으로 수정되었습니다.",
     "errorMessage": "수정에 실패했습니다.",
-    "generalError": "오류가 발생했습니다."
+    "generalError": "오류가 발생했습니다.",
+    "loadingText": "기본정보 수정 페이지 불러오는 중..."
   },
   "auth": {
     "signin": "로그인",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -853,6 +853,7 @@
       "errorTitle": "资料更新失败",
       "errorMessage": "更新失败。",
       "generalError": "发生错误。",
+      "loadingText": "正在加载资料编辑页面...",
       "confirm": "确认",
 
       "optional": "（可选）"
@@ -999,7 +1000,8 @@
       "reviews": "评论",
       "totalExperience": "总经验",
       "providedServices": "提供的服务",
-      "serviceAreas": "服务区域"
+      "serviceAreas": "服务区域",
+      "loadingText": "正在加载司机我的页面..."
     },
     "aria": {
       "searchResults": "共找到 {count} 位司机",
@@ -1092,7 +1094,8 @@
     "save": "保存更改",
     "successMessage": "个人资料更新成功。",
     "errorMessage": "更新失败。",
-    "generalError": "发生错误。"
+    "generalError": "发生错误。",
+    "loadingText": "正在加载基本信息编辑页面..."
   },
   "auth": {
     "signin": "登录",

--- a/src/pageComponents/moverMyPage/MoverMyPage.tsx
+++ b/src/pageComponents/moverMyPage/MoverMyPage.tsx
@@ -7,8 +7,8 @@ import defaultHeader from "@/assets/img/etc/detail-header.webp";
 import defaultProfileImage from "@/assets/img/mascot/moverprofile-lg.webp";
 import editIcon from "@/assets/icon/edit/icon-edit-white.svg";
 import editGrayIcon from "@/assets/icon/edit/icon-edit-gray.svg";
+import like from "@/assets/icon/like/icon-like-black.svg";
 import { CircleTextLabel } from "@/components/common/chips/CircleTextLabel";
-import Favorite from "@/components/common/button/Favorite";
 import { getRegionTranslation } from "@/lib/utils/translationUtils";
 import { useRouter } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
@@ -17,6 +17,7 @@ import ReviewList from "@/components/searchMover/[id]/ReviewList";
 import { IMoverInfo } from "@/types/mover.types";
 import { IReview } from "@/types/review";
 import findMoverApi from "@/lib/api/findMover.api";
+import MovingTruckLoader from "@/components/common/pending/MovingTruckLoader";
 
 const MoverMyPage = () => {
   const router = useRouter();
@@ -86,6 +87,15 @@ const MoverMyPage = () => {
     }
   }, [profile, locale]);
 
+  // 로딩 상태를 먼저 확인
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen w-full items-center justify-center bg-gray-200">
+        <MovingTruckLoader size="lg" loadingText={t("myPage.loadingText")} />
+      </div>
+    );
+  }
+
   if (error !== "") {
     return (
       <div className="bg-bg-primary flex min-h-screen w-full items-center justify-center">
@@ -118,24 +128,10 @@ const MoverMyPage = () => {
         </div>
       </header>
 
-      {/* 스켈레톤 UI */}
+      {/* 로딩 상태 */}
       {isLoading ? (
-        <div className="mx-auto max-w-6xl px-8 py-8">
-          <div className="flex flex-col gap-8 md:flex-row md:gap-12 lg:flex-row lg:gap-24">
-            <div className="flex w-full max-w-[821px] flex-col gap-10">
-              <div className="flex items-center gap-3">
-                <div className="w-20 h-20 bg-gray-200 animate-pulse rounded-[20px]" />
-                <div className="flex flex-col gap-2">
-                  <div className="w-32 h-8 bg-gray-200 animate-pulse rounded" />
-                  <div className="w-24 h-4 bg-gray-200 animate-pulse rounded" />
-                </div>
-              </div>
-              <div className="space-y-4">
-                <div className="w-full h-4 bg-gray-200 animate-pulse rounded" />
-                <div className="w-3/4 h-4 bg-gray-200 animate-pulse rounded" />
-              </div>
-            </div>
-          </div>
+        <div className="flex min-h-screen w-full items-center justify-center bg-gray-200">
+          <MovingTruckLoader size="lg" loadingText={t("myPage.loadingText")} />
         </div>
       ) : (
         <div className="mx-auto max-w-6xl px-8 py-8">
@@ -170,17 +166,8 @@ const MoverMyPage = () => {
                         </h1>
                       </div>
                       <div className="inline-flex items-center justify-start gap-1">
-                        <Favorite
-                          isFavorited={true}
-                          favoriteCount={profile.favoriteCount || 0}
-                          moverId={profile.id}
-                          favoritedColor="text-black"
-                          unfavoritedColor="text-black"
-                          textColor="text-gray-500"
-                          heartPosition="left"
-                          onFavoriteChange={() => {}}
-                          disabled={true}
-                        />
+                        <span className="text-md leading-6 font-normal text-gray-500">{profile.favoriteCount || 0}</span>
+                        <Image src={like} alt="" className="h-3 w-[14px]" role="presentation" aria-hidden="true" />
                       </div>
                     </div>
                   </div>
@@ -264,7 +251,7 @@ const MoverMyPage = () => {
                     </div>
                     <div className="inline-flex items-center justify-start gap-1.5">
                       <div className="text-primary-400 justify-center text-lg leading-loose font-bold sm:text-xl">
-                        {(profile.averageRating || 0).toFixed(1)}
+                        {(profile.avgRating || 0).toFixed(1)}
                       </div>
                     </div>
                   </div>

--- a/src/pageComponents/moverMyPage/edit/EditPage.tsx
+++ b/src/pageComponents/moverMyPage/edit/EditPage.tsx
@@ -12,6 +12,7 @@ import userApi from "@/lib/api/user.api";
 import { useAuth } from "@/providers/AuthProvider";
 import { useValidationRules } from "@/hooks/useValidationRules";
 import { showSuccessToast, showErrorToast } from "@/utils/toastUtils";
+import MovingTruckLoader from "@/components/common/pending/MovingTruckLoader";
 import * as Sentry from "@sentry/nextjs";
 
 
@@ -21,6 +22,7 @@ const EditPage = () => {
 
   const [formError, setFormError] = useState<string | null>(null);
   const [userProvider, setUserProvider] = useState<string>("LOCAL");
+  const [isLoading, setIsLoading] = useState(true);
   const t = useTranslations("edit");
   const authT = useTranslations("auth");
   const locale = useLocale();
@@ -41,6 +43,7 @@ const EditPage = () => {
   useEffect(() => {
     async function fetchUser() {
       try {
+        setIsLoading(true);
         const res = await userApi.getUser();
         if (res.success && res.data) {
           form.reset({
@@ -66,6 +69,8 @@ const EditPage = () => {
           },
         });
         showErrorToast("사용자 정보를 불러오는데 실패했습니다.");
+      } finally {
+        setIsLoading(false);
       }
     }
     fetchUser();
@@ -139,6 +144,14 @@ const EditPage = () => {
       showErrorToast(t("generalError"));
     }
   };
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen w-full items-center justify-center bg-white">
+        <MovingTruckLoader size="lg" loadingText={t("loadingText")} />
+      </div>
+    );
+  }
 
   return (
           <div className="flex min-h-[90vh] w-full items-center justify-center bg-white">
@@ -241,7 +254,7 @@ const EditPage = () => {
               <button
                 type="button"
                 className="h-[54px] w-full rounded-xl px-6 py-4 text-base font-semibold text-neutral-400 shadow-[4px_4px_10px_0px_rgba(195,217,242,0.20)] outline outline-1 outline-offset-[-1px] outline-stone-300 lg:h-[60px] lg:w-[240px] cursor-pointer"
-                onClick={() => router.back()}
+                onClick={() => router.push(`/${locale}/moverMyPage`)}
               >
                 {t("cancel")}
               </button>

--- a/src/pageComponents/profile/edit/MoverEditPage.tsx
+++ b/src/pageComponents/profile/edit/MoverEditPage.tsx
@@ -15,6 +15,7 @@ import { useLocale, useTranslations } from "next-intl";
 import { regionLabelMap } from "@/lib/utils/regionMapping";
 import { getServiceTypeTranslation, getRegionTranslation } from "@/lib/utils/translationUtils";
 import { showSuccessToast, showErrorToast } from "@/utils/toastUtils";
+import MovingTruckLoader from "@/components/common/pending/MovingTruckLoader";
 import * as Sentry from "@sentry/nextjs";
 
 
@@ -88,6 +89,7 @@ export default function MoverEditPage() {
     file: null,
     dataUrl: "",
   });
+  const [isLoading, setIsLoading] = useState(false);
 
   const methods = useForm({ defaultValues });
   const { watch, handleSubmit, setValue, reset } = methods;
@@ -95,6 +97,11 @@ export default function MoverEditPage() {
   const career = watch("career");
   const intro = watch("intro");
   const desc = watch("desc");
+
+  // 컴포넌트 마운트 시 로딩 상태 시작
+  useEffect(() => {
+    setIsLoading(true);
+  }, []);
 
   // 프로필 정보 불러와서 폼 초기값 세팅
   useEffect(() => {
@@ -152,6 +159,8 @@ export default function MoverEditPage() {
           },
         });
         showErrorToast("프로필 정보를 불러오는데 실패했습니다.");
+      } finally {
+        setIsLoading(false);
       }
     }
     fetchProfile();
@@ -234,6 +243,14 @@ export default function MoverEditPage() {
       showErrorToast(t("edit.generalError"));
     }
   };
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen w-full items-center justify-center bg-white">
+        <MovingTruckLoader size="lg" loadingText={t("edit.loadingText")} />
+      </div>
+    );
+  }
 
   return (
     <FormProvider {...methods}>
@@ -463,7 +480,7 @@ export default function MoverEditPage() {
                   width="w-full"
                   height="h-[54px] lg:h-14"
                   className="!hover:bg-white !focus:bg-white !active:bg-white order-2 items-center justify-center rounded-2xl border border-[1px] !border-[#C4C4C4] bg-white px-6 py-4 text-base leading-relaxed font-semibold !text-[#C4C4C4] shadow-none outline-1 outline-offset-[-1px] lg:order-1"
-                  onClick={() => window.history.back()}
+                  onClick={() => router.push(`/${locale}/moverMyPage`)}
                 >
                   <div className="justify-center text-center">{t("edit.cancel")}</div>
                 </Button>


### PR DESCRIPTION
## ✨ 작업 개요
- 기사님 관련 페이지들의 UI/UX 일관성 개선 및 로딩 상태 통일화 작업을 진행했습니다.
- 기존에 각 페이지마다 다른 로딩 방식과 컴포넌트를 사용하던 것을 MovingTruckLoader 컴포넌트로 통일하고, 찜 하트 크기와 평점 데이터 소스도 일관성 있게 수정했습니다.

## ✅ 주요 작업 내용
- 기사님 마이페이지 찜 하트 크기 통일: Favorite 컴포넌트(24px) → Image 컴포넌트(14px)로 변경하여 기사님 상세페이지와 동일한 크기 적용
- 기사님 프로필 수정 페이지 취소 버튼 개선: window.history.back() → router.push('/moverMyPage')로 변경하여 일관된 마이페이지 이동 구현
- 기사님 기본정보 수정 페이지 취소 버튼 개선: router.back() → router.push('/moverMyPage')로 변경
- 기사님 마이페이지 평점 데이터 통일: profile.averageRating → profile.avgRating로 변경하여 활동 현황과 리뷰 통계의 평점 일치
- 로딩 컴포넌트 통일화
## 🔄 관련 이슈
Closes #이슈번호

## 📸 스크린샷 (선택)
> before / after 비교가 있으면 같이 첨부해주세요

## 🧪 테스트 방법 (선택)
- [x] 기사님 마이페이지 진입 시 로딩 화면 정상 표시
- [x] 기사님 프로필 수정 페이지 진입 시 로딩 화면 정상 표시
- [x] 기사님 기본정보 수정 페이지 진입 시 로딩 화면 정상 표시

## 📝 비고
- (버그, 추후 개선사항 등)